### PR TITLE
Use plain bullets for post-merge reminders

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "opsx",
       "source": "./src",
       "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-      "version": "1.0.39"
+      "version": "1.0.40"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-07 — Post-Merge Reminder Format
+
+### Changed
+- Post-merge items in generated task lists now use plain bullet format instead of unchecked checkboxes — they are visual reminders, not tracked tasks, and no longer count toward progress totals
+- Post-merge reminders appear in a dedicated "Post-Merge Reminders" section, separate from the Standard Tasks section
+- Constitution and bootstrap templates updated with Pre-Merge / Post-Merge subsection structure
+
 ## 2026-04-07 — Fix Stale Spec References
 
 ### Fixed

--- a/docs/capabilities/task-implementation.md
+++ b/docs/capabilities/task-implementation.md
@@ -24,7 +24,7 @@ Tasks are implemented sequentially in the order listed because the task list rep
 - **Resume from where you left off** -- skips already-completed tasks and starts from the first pending one.
 - **Pause on blockers** -- stops and asks for clarification when a task is ambiguous, a design issue is discovered, or a technical constraint prevents progress.
 - **Direct spec editing** -- specs at `openspec/specs/` can be modified during implementation when task requirements include spec changes.
-- **Standard tasks separation** -- post-implementation steps (changelog, docs, version bump, push) are tracked as checkboxes in the task list but not executed by apply. Constitution-defined pre-merge extras are executed during the post-apply workflow; post-merge tasks remain unchecked as reminders.
+- **Standard tasks separation** -- post-implementation steps (changelog, docs, version bump, push) are tracked as checkboxes in the task list but not executed by apply. Constitution-defined pre-merge extras are executed during the post-apply workflow. Post-merge reminders appear in a dedicated section as plain bullets — they are not tracked tasks and do not count toward progress.
 - **Parallelizable task markers** -- tasks marked with `[P]` indicate they can be done in parallel. The marker is informational only and does not change progress counting logic.
 
 ## Behavior
@@ -57,9 +57,11 @@ Specs at `openspec/specs/` can be modified during implementation. When a task re
 
 ### Standard Tasks (Post-Implementation)
 
-Every task list includes a final section with post-implementation workflow steps (changelog, docs, version bump, commit and push). These standard tasks are checkboxes like any other task, but `/opsx:apply` does not execute them. They remain unchecked after apply completes, serving as an auditable checklist for the post-apply workflow. Standard tasks are included in progress counts -- after apply, you might see "5/9 tasks complete" reflecting that 4 standard tasks still need to be done manually. If you run `/opsx:archive` while standard tasks are unchecked, the system warns you that tasks remain incomplete. Projects can add project-specific extras to the standard tasks via the constitution's `## Standard Tasks` section.
+Every task list includes a Standard Tasks section with post-implementation workflow steps (changelog, docs, version bump, commit and push). These standard tasks are checkboxes like any other task, but `/opsx:apply` does not execute them. They remain unchecked after apply completes, serving as an auditable checklist for the post-apply workflow. Standard tasks are included in progress counts -- after apply, you might see "5/9 tasks complete" reflecting that standard tasks still need to be done manually. Projects can add project-specific pre-merge extras to the standard tasks via the constitution's `## Standard Tasks > ### Pre-Merge` section.
 
-During the post-apply workflow, universal standard task checkboxes and constitution-defined pre-merge extras (e.g., updating a PR to ready-for-review) are marked complete before creating the final commit. This ensures the committed tasks.md reflects the fully-checked state, eliminating the need for an extra follow-up commit just for checkboxes. Post-merge standard tasks (e.g., updating a plugin locally) remain unchecked as reminders for manual execution after the PR is merged.
+Post-merge reminders (e.g., updating a plugin locally) appear in a separate "Post-Merge Reminders" section using plain bullet format — no checkboxes. They are not counted in progress totals and serve purely as visual reminders for manual execution after the PR is merged. Projects define post-merge items in the constitution's `## Standard Tasks > ### Post-Merge` section.
+
+During the post-apply workflow, universal standard task checkboxes and constitution-defined pre-merge extras (e.g., updating a PR to ready-for-review) are marked complete before creating the final commit. This ensures the committed tasks.md reflects the fully-checked state, eliminating the need for an extra follow-up commit just for checkboxes.
 
 ### All Tasks Already Complete
 

--- a/openspec/CONSTITUTION.md
+++ b/openspec/CONSTITUTION.md
@@ -48,4 +48,4 @@
 - [ ] Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #X"`)
 
 ### Post-Merge
-- [ ] Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/design.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/design.md
@@ -1,0 +1,41 @@
+# Technical Design: Post-Merge Reminder Format
+
+## Context
+
+Post-merge tasks in the constitution currently use `- [ ]` checkbox format. The task-implementation spec requires them to "remain unchecked as reminders." This creates unnecessary complexity — the apply skill must distinguish pre-merge (mark complete) from post-merge (leave unchecked), and progress counting includes items that can't be completed within the workflow.
+
+## Architecture & Components
+
+**Files to edit:**
+1. `openspec/CONSTITUTION.md` — Change Post-Merge `- [ ]` to `- ` (1 item)
+2. `openspec/specs/task-implementation/spec.md` — Update ~6 references to post-merge format
+3. `openspec/templates/tasks.md` — Add clarification in instruction that post-merge items are plain bullets
+
+## Goals & Success Metrics
+
+- Constitution Post-Merge section uses `- ` not `- [ ]` — PASS if grep finds 0 checkboxes under Post-Merge
+- task-implementation spec does not reference post-merge items as `- [ ]` — PASS if no "remain unchecked" or "remain as `- [ ]`" for post-merge
+
+## Non-Goals
+
+- Changing pre-merge task format
+- Migrating existing completed changes' tasks.md files
+
+## Decisions
+
+| Decision | Rationale | Alternatives |
+|----------|-----------|--------------|
+| Plain bullet `- ` for post-merge | Not counted by checkbox parser; visually distinct; no special handling needed | Keep `- [ ]` with exclusion logic (more complex) |
+| Template instruction clarification only | "Copy constitution items verbatim" already handles propagation; just add a note about the format distinction | Edit template body to add a post-merge section (over-prescriptive) |
+
+## Risks & Trade-offs
+
+- [Progress counts change] → Existing tasks.md files are immutable. Only new changes are affected. Progress totals will be lower (correct behavior).
+
+## Open Questions
+
+No open questions.
+
+## Assumptions
+
+No assumptions made.

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/preflight.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/preflight.md
@@ -1,0 +1,39 @@
+# Pre-Flight Check: Post-Merge Reminder Format
+
+## A. Traceability Matrix
+
+- [x] Constitution Post-Merge format → CONSTITUTION.md edit → 1 item
+- [x] Spec post-merge references → task-implementation/spec.md edit → ~6 references
+- [x] Template instruction → tasks.md template instruction update → 1 clarification
+
+## B. Gap Analysis
+
+No gaps found. All three affected files are addressed.
+
+## C. Side-Effect Analysis
+
+- **Progress counts**: Future tasks.md files will have lower totals (post-merge items not counted). This is intentional — correct behavior.
+- **Apply skill behavior**: No change. The apply skill only processes checkboxes; plain bullets are already ignored.
+- **Existing tasks.md**: Immutable. No migration needed.
+
+No regression risks.
+
+## D. Constitution Check
+
+This change modifies the constitution itself. The change is additive (refining format) and does not conflict with any existing rules.
+
+## E. Duplication & Consistency
+
+- Pre-merge tasks remain `- [ ]` checkboxes (consistent with universal standard tasks)
+- Post-merge items become `- ` plain bullets (consistent with their "reminder" role)
+- No contradictions.
+
+## F. Assumption Audit
+
+No assumptions in spec or design.
+
+## G. Review Marker Audit
+
+No `<!-- REVIEW -->` markers found.
+
+**Verdict: PASS**

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/proposal.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Post-merge tasks use `- [ ]` checkbox format, making them count in progress totals and requiring special "remain unchecked" handling in the spec. Switching to plain bullets makes them visually distinct reminders that don't pollute progress tracking.
+
+## What Changes
+
+- Change constitution Post-Merge items from `- [ ]` to `- ` (plain bullet)
+- Update task-implementation spec to reflect plain bullet format for post-merge reminders
+- Update tasks template instruction to clarify post-merge items use plain bullet format
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `task-implementation`: Update post-merge task format from unchecked checkbox to plain bullet reminder
+
+### Removed Capabilities
+
+None.
+
+### Consolidation Check
+
+N/A — no new specs proposed.
+
+## Impact
+
+- Constitution format change
+- Spec text updates (no behavioral change to apply skill — plain bullets are already not parsed as tasks)
+- Future tasks.md files will have plain bullets for post-merge items (via verbatim copy from constitution)
+
+## Scope & Boundaries
+
+**In scope:**
+- Constitution Post-Merge section format
+- task-implementation/spec.md references to post-merge format
+- Tasks template instruction clarification
+
+**Out of scope:**
+- Pre-merge tasks (keep `- [ ]` checkbox format)
+- Universal standard tasks in template body (keep `- [ ]`)
+- Existing completed changes' tasks.md files

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/research.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/research.md
@@ -1,0 +1,52 @@
+# Research: Post-Merge Reminder Format
+
+## 1. Current State
+
+Post-merge tasks in the constitution use `- [ ]` checkbox format, identical to pre-merge tasks. This creates two problems:
+1. They count toward progress totals (e.g., "23/24 tasks complete") even though they can't be completed until after the PR is merged
+2. The spec requires special handling to "remain unchecked" — an awkward contract when the format invites checking
+
+**Affected files:**
+- `openspec/CONSTITUTION.md` — Post-Merge section uses `- [ ]`
+- `openspec/specs/task-implementation/spec.md` — multiple references to post-merge tasks "remaining as `- [ ]`"
+- `openspec/templates/tasks.md` — instruction says "Copy constitution items verbatim" (works automatically once constitution changes)
+
+## 2. External Research
+
+N/A — internal formatting decision.
+
+## 3. Approaches
+
+| Approach | Pro | Contra |
+|----------|-----|--------|
+| Plain bullet `- ` for post-merge items | Visually distinct from actionable tasks; not counted in progress; no special handling needed | Minor breaking change to existing tasks.md format |
+| Keep `- [ ]` but exclude from count | No format change | Requires parsing logic to distinguish pre/post-merge; spec already complex |
+
+## 4. Risks & Constraints
+
+- Template instruction "Copy constitution items verbatim" means the format change propagates automatically — no template edit needed.
+- Existing completed changes with old-format tasks.md are immutable — no migration needed.
+
+## 5. Coverage Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Scope | Clear | Constitution + task-implementation spec |
+| Behavior | Clear | Plain bullets excluded from checkbox count by definition |
+| Data Model | Clear | N/A |
+| UX | Clear | Cleaner progress reporting |
+| Integration | Clear | Template verbatim copy handles propagation |
+| Edge Cases | Clear | Existing tasks.md files unaffected |
+| Constraints | Clear | No code changes |
+| Terminology | Clear | "reminder" vs "task" |
+| Non-Functional | Clear | N/A |
+
+## 6. Open Questions
+
+All categories are Clear. No questions needed.
+
+## 7. Decisions
+
+| # | Decision | Rationale | Alternatives Considered |
+|---|----------|-----------|------------------------|
+| 1 | Use plain bullet `- ` for post-merge items | Visually distinct, not counted in progress, no special handling | Keep `- [ ]` with counting exclusion (more complex) |

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
@@ -6,14 +6,14 @@ No foundation tasks.
 
 ## 2. Implementation
 
-- [ ] 2.1. Update `openspec/CONSTITUTION.md`: change Post-Merge items from `- [ ]` to `- ` (plain bullet)
-- [ ] 2.2. Update `openspec/specs/task-implementation/spec.md`: rewrite post-merge references from "remain unchecked / remain as `- [ ]`" to "use plain bullet format (no checkbox)"
-- [ ] 2.3. Update `openspec/templates/tasks.md`: add clarification in instruction that post-merge constitution items use plain bullet format
+- [x] 2.1. Update `openspec/CONSTITUTION.md`: change Post-Merge items from `- [ ]` to `- ` (plain bullet)
+- [x] 2.2. Update `openspec/specs/task-implementation/spec.md`: rewrite post-merge references from "remain unchecked / remain as `- [ ]`" to "use plain bullet format (no checkbox)"
+- [x] 2.3. Update `openspec/templates/tasks.md`: add clarification in instruction that post-merge constitution items use plain bullet format
 
 ## 3. QA Loop & Human Approval
 
-- [ ] 3.1. Metric Check: grep constitution for post-merge checkboxes; grep spec for "remain unchecked" — PASS / FAIL
-- [ ] 3.2. Auto-Verify: Run `/opsx:verify`
+- [x] 3.1. Metric Check: grep constitution for post-merge checkboxes; grep spec for "remain unchecked" — PASS / FAIL
+- [x] 3.2. Auto-Verify: Run `/opsx:verify`
 - [ ] 3.3. User Testing: **Stop here!** Ask the user for manual approval.
 - [ ] 3.4. Fix Loop: On verify issues or bug reports → fix → re-verify.
 - [ ] 3.5. Final Verify: Skip if 3.4 was not entered.

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
@@ -14,16 +14,16 @@ No foundation tasks.
 
 - [x] 3.1. Metric Check: grep constitution for post-merge checkboxes; grep spec for "remain unchecked" — PASS / FAIL
 - [x] 3.2. Auto-Verify: Run `/opsx:verify`
-- [ ] 3.3. User Testing: **Stop here!** Ask the user for manual approval.
-- [ ] 3.4. Fix Loop: On verify issues or bug reports → fix → re-verify.
-- [ ] 3.5. Final Verify: Skip if 3.4 was not entered.
-- [ ] 3.6. Approval: Only finish on explicit **"Approved"** by the user.
+- [x] 3.3. User Testing: **Stop here!** Ask the user for manual approval.
+- [x] 3.4. Fix Loop: On verify issues or bug reports → fix → re-verify.
+- [x] 3.5. Final Verify: Skip if 3.4 was not entered.
+- [x] 3.6. Approval: Only finish on explicit **"Approved"** by the user.
 
 ## 4. Standard Tasks (Post-Implementation)
 
-- [ ] 4.1. Generate changelog (`/opsx:changelog`)
-- [ ] 4.2. Generate/update docs (`/opsx:docs task-implementation`)
-- [ ] 4.3. Bump version
-- [ ] 4.4. Commit and push to remote
-- [ ] 4.5. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "..."`)
+- [x] 4.1. Generate changelog (`/opsx:changelog`)
+- [x] 4.2. Generate/update docs (`/opsx:docs task-implementation`)
+- [x] 4.3. Bump version
+- [x] 4.4. Commit and push to remote
+- [x] 4.5. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "..."`)
 - Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
+++ b/openspec/changes/2026-04-07-post-merge-reminder-format/tasks.md
@@ -1,0 +1,29 @@
+# Implementation Tasks: Post-Merge Reminder Format
+
+## 1. Foundation
+
+No foundation tasks.
+
+## 2. Implementation
+
+- [ ] 2.1. Update `openspec/CONSTITUTION.md`: change Post-Merge items from `- [ ]` to `- ` (plain bullet)
+- [ ] 2.2. Update `openspec/specs/task-implementation/spec.md`: rewrite post-merge references from "remain unchecked / remain as `- [ ]`" to "use plain bullet format (no checkbox)"
+- [ ] 2.3. Update `openspec/templates/tasks.md`: add clarification in instruction that post-merge constitution items use plain bullet format
+
+## 3. QA Loop & Human Approval
+
+- [ ] 3.1. Metric Check: grep constitution for post-merge checkboxes; grep spec for "remain unchecked" — PASS / FAIL
+- [ ] 3.2. Auto-Verify: Run `/opsx:verify`
+- [ ] 3.3. User Testing: **Stop here!** Ask the user for manual approval.
+- [ ] 3.4. Fix Loop: On verify issues or bug reports → fix → re-verify.
+- [ ] 3.5. Final Verify: Skip if 3.4 was not entered.
+- [ ] 3.6. Approval: Only finish on explicit **"Approved"** by the user.
+
+## 4. Standard Tasks (Post-Implementation)
+
+- [ ] 4.1. Generate changelog (`/opsx:changelog`)
+- [ ] 4.2. Generate/update docs (`/opsx:docs task-implementation`)
+- [ ] 4.3. Bump version
+- [ ] 4.4. Commit and push to remote
+- [ ] 4.5. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "..."`)
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/specs/task-implementation/spec.md
+++ b/openspec/specs/task-implementation/spec.md
@@ -85,18 +85,18 @@ The system SHALL report implementation progress using checkbox counts from the t
 
 ### Requirement: Standard Tasks Exclusion from Apply Scope
 
-The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge items SHALL appear in a separate section (section 5: "Post-Merge Reminders") using plain bullet format (`- ` without checkbox). Plain bullets are not counted in progress totals and are not parsed by the apply skill. If no post-merge items exist in the constitution, section 5 SHALL be omitted.
+The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge items SHALL appear in a separate "Post-Merge Reminders" section using plain bullet format (`- ` without checkbox). Plain bullets are not counted in progress totals and are not parsed by the apply skill. If no post-merge items exist in the constitution, the Post-Merge Reminders section SHALL be omitted.
 
 **User Story:** As a developer I want post-implementation workflow steps tracked as checkboxes in my task list but not executed by apply, so that I have a visible, auditable checklist for post-apply steps without conflating them with implementation work.
 
 #### Scenario: Apply skips standard tasks section
 
-- **GIVEN** a tasks.md with sections 1-3 (Foundation, Implementation, QA Loop), section 4 (Standard Tasks Post-Implementation) containing 3 unchecked items, and section 5 (Post-Merge Reminders) containing plain bullet reminders
+- **GIVEN** a tasks.md with Foundation, Implementation, and QA Loop sections, a Standard Tasks (Post-Implementation) section containing 3 unchecked items, and a Post-Merge Reminders section containing plain bullet reminders
 - **WHEN** the user invokes `/opsx:apply`
-- **THEN** the system SHALL work through pending tasks in sections 1-3 only
-- **AND** SHALL NOT attempt to execute tasks in sections 4 or 5
-- **AND** section 4 items SHALL remain as `- [ ]` after apply completes
-- **AND** section 5 plain bullet reminders SHALL remain unchanged
+- **THEN** the system SHALL work through pending tasks in Foundation, Implementation, and QA Loop sections only
+- **AND** SHALL NOT attempt to execute Standard Tasks or Post-Merge Reminders
+- **AND** Standard Tasks items SHALL remain as `- [ ]` after apply completes
+- **AND** Post-Merge Reminders plain bullets SHALL remain unchanged
 
 #### Scenario: Progress count includes standard tasks
 
@@ -107,17 +107,17 @@ The system SHALL distinguish between implementation tasks (Foundation, Implement
 
 #### Scenario: All standard tasks marked before commit
 
-- **GIVEN** a tasks.md with all implementation tasks complete, section 4 standard tasks including universal steps (changelog, docs, version bump, commit and push) and pre-merge extras (e.g., update PR) as unchecked checkboxes, and section 5 post-merge reminders (e.g., update plugin) as plain bullets
+- **GIVEN** a tasks.md with all implementation tasks complete, Standard Tasks including universal steps (changelog, docs, version bump, commit and push) and pre-merge extras (e.g., update PR) as unchecked checkboxes, and Post-Merge Reminders (e.g., update plugin) as plain bullets
 - **AND** the post-apply workflow has completed all steps including pre-merge constitution extras
 - **WHEN** the system is about to create the final commit
 - **THEN** the system SHALL mark universal and pre-merge standard task checkboxes as `- [x]` in tasks.md
-- **AND** section 5 post-merge reminders SHALL remain as plain bullets (they have no checkbox to mark)
-- **AND** the committed tasks.md SHALL reflect the section 4/5 distinction
+- **AND** Post-Merge Reminders SHALL remain as plain bullets (they have no checkbox to mark)
+- **AND** the committed tasks.md SHALL reflect the Standard Tasks / Post-Merge Reminders distinction
 - **AND** no extra follow-up commit SHALL be needed for pre-merge standard task checkboxes
 
 ### Requirement: Spec Edits During Implementation
 
-The system SHALL allow implementation tasks to modify spec files (`openspec/specs/`) when required by the task description. Specs are edited directly during the specs stage and may need refinements during implementation. Implementation tasks (sections 1-2) SHALL NOT include post-apply workflow steps (changelog, docs, version bump). These steps SHALL appear in the Standard Tasks section.
+The system SHALL allow implementation tasks to modify spec files (`openspec/specs/`) when required by the task description. Specs are edited directly during the specs stage and may need refinements during implementation. Implementation tasks (Foundation, Implementation sections) SHALL NOT include post-apply workflow steps (changelog, docs, version bump). These steps SHALL appear in the Standard Tasks section.
 
 **User Story:** As a developer I want to be able to refine specs during implementation if needed, so that specs stay accurate as implementation reveals edge cases.
 

--- a/openspec/specs/task-implementation/spec.md
+++ b/openspec/specs/task-implementation/spec.md
@@ -85,18 +85,18 @@ The system SHALL report implementation progress using checkbox counts from the t
 
 ### Requirement: Standard Tasks Exclusion from Apply Scope
 
-The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge items SHALL use plain bullet format (`- ` without checkbox) as reminders for manual execution after the PR is merged. Plain bullets are not counted in progress totals and are not parsed by the apply skill.
+The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge items SHALL appear in a separate section (section 5: "Post-Merge Reminders") using plain bullet format (`- ` without checkbox). Plain bullets are not counted in progress totals and are not parsed by the apply skill. If no post-merge items exist in the constitution, section 5 SHALL be omitted.
 
 **User Story:** As a developer I want post-implementation workflow steps tracked as checkboxes in my task list but not executed by apply, so that I have a visible, auditable checklist for post-apply steps without conflating them with implementation work.
 
 #### Scenario: Apply skips standard tasks section
 
-- **GIVEN** a tasks.md with sections 1-3 (Foundation, Implementation, QA Loop) and section 4 (Standard Tasks Post-Implementation) containing 3 unchecked items
+- **GIVEN** a tasks.md with sections 1-3 (Foundation, Implementation, QA Loop), section 4 (Standard Tasks Post-Implementation) containing 3 unchecked items, and section 5 (Post-Merge Reminders) containing plain bullet reminders
 - **WHEN** the user invokes `/opsx:apply`
 - **THEN** the system SHALL work through pending tasks in sections 1-3 only
-- **AND** SHALL NOT attempt to execute tasks in section 4
-- **AND** section 4 checkbox items SHALL remain as `- [ ]` after apply completes
-- **AND** section 4 plain bullet items (post-merge reminders) SHALL remain unchanged
+- **AND** SHALL NOT attempt to execute tasks in sections 4 or 5
+- **AND** section 4 items SHALL remain as `- [ ]` after apply completes
+- **AND** section 5 plain bullet reminders SHALL remain unchanged
 
 #### Scenario: Progress count includes standard tasks
 
@@ -107,12 +107,12 @@ The system SHALL distinguish between implementation tasks (Foundation, Implement
 
 #### Scenario: All standard tasks marked before commit
 
-- **GIVEN** a tasks.md with all implementation tasks complete and standard tasks including universal steps (changelog, docs, version bump, commit and push), pre-merge extras (e.g., update PR) as unchecked checkboxes, and post-merge reminders (e.g., update plugin) as plain bullets
+- **GIVEN** a tasks.md with all implementation tasks complete, section 4 standard tasks including universal steps (changelog, docs, version bump, commit and push) and pre-merge extras (e.g., update PR) as unchecked checkboxes, and section 5 post-merge reminders (e.g., update plugin) as plain bullets
 - **AND** the post-apply workflow has completed all steps including pre-merge constitution extras
 - **WHEN** the system is about to create the final commit
 - **THEN** the system SHALL mark universal and pre-merge standard task checkboxes as `- [x]` in tasks.md
-- **AND** post-merge reminders SHALL remain as plain bullets (they have no checkbox to mark)
-- **AND** the committed tasks.md SHALL reflect the pre-merge/post-merge distinction
+- **AND** section 5 post-merge reminders SHALL remain as plain bullets (they have no checkbox to mark)
+- **AND** the committed tasks.md SHALL reflect the section 4/5 distinction
 - **AND** no extra follow-up commit SHALL be needed for pre-merge standard task checkboxes
 
 ### Requirement: Spec Edits During Implementation

--- a/openspec/specs/task-implementation/spec.md
+++ b/openspec/specs/task-implementation/spec.md
@@ -85,7 +85,7 @@ The system SHALL report implementation progress using checkbox counts from the t
 
 ### Requirement: Standard Tasks Exclusion from Apply Scope
 
-The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge tasks SHALL remain unchecked as reminders for manual execution after the PR is merged.
+The system SHALL distinguish between implementation tasks (Foundation, Implementation, QA Loop sections) and standard tasks (Post-Implementation section) in the generated `tasks.md`. During `/opsx:apply`, the system SHALL only process tasks in the implementation and QA sections. Standard tasks in the Post-Implementation section SHALL NOT be executed by the apply phase. Standard tasks SHALL remain as unchecked `- [ ]` items after apply completes. The standard tasks section SHALL be included in the total checkbox count for progress reporting, reflecting the full workflow completion state. During the post-apply workflow, the system SHALL mark all standard task checkboxes as complete in `tasks.md` — including universal steps and constitution-defined pre-merge extras — before creating the final commit, so that the committed file reflects the fully-checked state. Constitution-defined post-merge items SHALL use plain bullet format (`- ` without checkbox) as reminders for manual execution after the PR is merged. Plain bullets are not counted in progress totals and are not parsed by the apply skill.
 
 **User Story:** As a developer I want post-implementation workflow steps tracked as checkboxes in my task list but not executed by apply, so that I have a visible, auditable checklist for post-apply steps without conflating them with implementation work.
 
@@ -95,7 +95,8 @@ The system SHALL distinguish between implementation tasks (Foundation, Implement
 - **WHEN** the user invokes `/opsx:apply`
 - **THEN** the system SHALL work through pending tasks in sections 1-3 only
 - **AND** SHALL NOT attempt to execute tasks in section 4
-- **AND** section 4 items SHALL remain as `- [ ]` after apply completes
+- **AND** section 4 checkbox items SHALL remain as `- [ ]` after apply completes
+- **AND** section 4 plain bullet items (post-merge reminders) SHALL remain unchanged
 
 #### Scenario: Progress count includes standard tasks
 
@@ -106,11 +107,11 @@ The system SHALL distinguish between implementation tasks (Foundation, Implement
 
 #### Scenario: All standard tasks marked before commit
 
-- **GIVEN** a tasks.md with all implementation tasks complete and standard tasks including universal steps (changelog, docs, version bump, commit and push), pre-merge extras (e.g., update PR), and post-merge extras (e.g., update plugin) unchecked
+- **GIVEN** a tasks.md with all implementation tasks complete and standard tasks including universal steps (changelog, docs, version bump, commit and push), pre-merge extras (e.g., update PR) as unchecked checkboxes, and post-merge reminders (e.g., update plugin) as plain bullets
 - **AND** the post-apply workflow has completed all steps including pre-merge constitution extras
 - **WHEN** the system is about to create the final commit
 - **THEN** the system SHALL mark universal and pre-merge standard task checkboxes as `- [x]` in tasks.md
-- **AND** post-merge standard tasks SHALL remain as `- [ ]`
+- **AND** post-merge reminders SHALL remain as plain bullets (they have no checkbox to mark)
 - **AND** the committed tasks.md SHALL reflect the pre-merge/post-merge distinction
 - **AND** no extra follow-up commit SHALL be needed for pre-merge standard task checkboxes
 
@@ -146,7 +147,7 @@ The system SHALL allow implementation tasks to modify spec files (`openspec/spec
 - **No standard tasks in constitution:** If the project constitution does not define a `## Standard Tasks` section, the tasks.md SHALL omit the Post-Implementation section entirely. Apply behavior is unchanged.
 - **Standard tasks manually checked:** If a user manually marks standard tasks as `- [x]` before completion, the system SHALL count them as complete in progress totals.
 - **Apply re-invoked after standard tasks complete:** If all tasks including standard tasks are marked complete, the system SHALL report "All tasks complete" and suggest running the post-apply workflow.
-- **Pre-merge extras executed during post-apply:** Constitution-defined pre-merge standard tasks (e.g., "Update PR") SHALL be executed during the post-apply workflow after commit and push. Post-merge tasks (e.g., "Update plugin") SHALL remain unchecked — they are executed manually after the PR is merged.
+- **Pre-merge extras executed during post-apply:** Constitution-defined pre-merge standard tasks (e.g., "Update PR") SHALL be executed during the post-apply workflow after commit and push. Post-merge reminders (e.g., "Update plugin") use plain bullet format and are executed manually after the PR is merged.
 - **Constitution extra fails:** If a constitution extra fails (e.g., `gh pr ready` fails due to network), the agent SHALL note the failure, skip marking that task as complete, and continue with remaining extras. The failed task remains as `- [ ]` for manual resolution.
 - **Partial post-apply workflow:** If the post-apply workflow is interrupted (e.g., changelog fails), only the steps that actually completed should be marked. The commit step should not be marked if the commit does not happen.
 
@@ -155,5 +156,5 @@ The system SHALL allow implementation tasks to modify spec files (`openspec/spec
 - tasks.md uses standard markdown checkbox format (- [ ] / - [x]) as defined by the schema. <!-- ASSUMPTION: Checkbox format stability -->
 - Task ordering in tasks.md represents the recommended implementation sequence, though the system may encounter out-of-order completions. <!-- ASSUMPTION: Ordering is recommended not enforced -->
 - The apply skill has read/write access to both the tasks.md file and all project source files. <!-- ASSUMPTION: Skill file access -->
-- Standard tasks in the constitution use the same markdown checkbox format (- [ ]) as implementation tasks. <!-- ASSUMPTION: Constitution checkbox format -->
+- Pre-merge standard tasks in the constitution use markdown checkbox format (- [ ]). Post-merge reminders use plain bullet format (- ) without checkboxes. <!-- ASSUMPTION: Constitution task format -->
 - The agent can distinguish task sections by their ## heading numbers/titles. <!-- ASSUMPTION: Section heading parsing -->

--- a/openspec/templates/constitution.md
+++ b/openspec/templates/constitution.md
@@ -27,5 +27,12 @@ instruction: |
 
 ## Standard Tasks
 
-<!-- Project-specific extras appended to the universal standard tasks in the schema template.
-     Add checkbox items here for steps that should appear in every tasks.md after the universal steps. -->
+<!-- Project-specific extras appended to the universal standard tasks in the tasks template.
+     Pre-merge items use checkbox format and are executed during post-apply workflow.
+     Post-merge items use plain bullet format and are manual reminders after PR merge. -->
+
+### Pre-Merge
+<!-- - [ ] Example: Update PR body with summary -->
+
+### Post-Merge
+<!-- - Example: Run deployment script -->

--- a/openspec/templates/tasks.md
+++ b/openspec/templates/tasks.md
@@ -27,10 +27,16 @@ instruction: |
   Standard Tasks: The template includes a section 4 with universal
   post-implementation steps (changelog, docs, version bump, push).
   Always include this section as-is. If the project constitution defines
-  a "## Standard Tasks" section, append its items after the universal
-  steps. Copy constitution items verbatim — pre-merge items use
-  `- [ ]` checkbox format, post-merge items use plain `- ` bullet
-  format (no checkbox). Plain bullets are reminders, not tracked tasks.
+  a "## Standard Tasks" section with a "### Pre-Merge" subsection,
+  append those pre-merge items (as `- [ ]` checkboxes) after the
+  universal steps in section 4.
+
+  Post-Merge Reminders: If the constitution's Standard Tasks has a
+  "### Post-Merge" subsection, add a separate section 5 titled
+  "Post-Merge Reminders". Copy post-merge items as plain `- ` bullets
+  (no checkbox, no numbering). These are not tracked tasks — just
+  reminders for manual execution after the PR is merged. If no
+  Post-Merge subsection exists, omit section 5 entirely.
 ---
 # Implementation Tasks: [Feature Name]
 
@@ -53,8 +59,13 @@ instruction: |
 
 ## 4. Standard Tasks (Post-Implementation)
 <!-- Universal post-implementation steps. Always include this section.
-     If the constitution defines ## Standard Tasks, append those items after these. -->
+     If the constitution defines ## Standard Tasks > ### Pre-Merge, append those items after these. -->
 - [ ] 4.1. Generate changelog (`/opsx:changelog`)
 - [ ] 4.2. Generate/update docs (`/opsx:docs`)
 - [ ] 4.3. Bump version
 - [ ] 4.4. Commit and push to remote
+
+## 5. Post-Merge Reminders
+<!-- Not tracked as tasks. Executed manually after the PR is merged.
+     If the constitution defines ## Standard Tasks > ### Post-Merge, copy those items here as plain bullets.
+     Omit this section entirely if no post-merge items exist. -->

--- a/openspec/templates/tasks.md
+++ b/openspec/templates/tasks.md
@@ -28,7 +28,9 @@ instruction: |
   post-implementation steps (changelog, docs, version bump, push).
   Always include this section as-is. If the project constitution defines
   a "## Standard Tasks" section, append its items after the universal
-  steps. Copy constitution items verbatim.
+  steps. Copy constitution items verbatim — pre-merge items use
+  `- [ ]` checkbox format, post-merge items use plain `- ` bullet
+  format (no checkbox). Plain bullets are reminders, not tracked tasks.
 ---
 # Implementation Tasks: [Feature Name]
 

--- a/src/.claude-plugin/plugin.json
+++ b/src/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx",
   "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "author": {
     "name": "fritze.dev"
   },

--- a/src/templates/constitution.md
+++ b/src/templates/constitution.md
@@ -27,5 +27,12 @@ instruction: |
 
 ## Standard Tasks
 
-<!-- Project-specific extras appended to the universal standard tasks in the schema template.
-     Add checkbox items here for steps that should appear in every tasks.md after the universal steps. -->
+<!-- Project-specific extras appended to the universal standard tasks in the tasks template.
+     Pre-merge items use checkbox format and are executed during post-apply workflow.
+     Post-merge items use plain bullet format and are manual reminders after PR merge. -->
+
+### Pre-Merge
+<!-- - [ ] Example: Update PR body with summary -->
+
+### Post-Merge
+<!-- - Example: Run deployment script -->


### PR DESCRIPTION
## Summary

- Post-merge items in constitution changed from `- [ ]` checkbox to `- ` plain bullet
- Dedicated "Post-Merge Reminders" section in tasks template (separate from Standard Tasks)
- Constitution templates updated with Pre-Merge / Post-Merge subsection structure
- task-implementation spec updated to use section names instead of numbers

## Test plan
- [x] Constitution Post-Merge section uses plain bullets
- [x] task-implementation spec has no numeric section references
- [x] Both constitution templates (src + openspec) updated
- [x] tasks template has section 5 for post-merge reminders

🤖 Generated with [Claude Code](https://claude.com/claude-code)