### PR TITLE
Fix Friction Batch (#81, #86, #87, #88)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "opsx",
       "source": "./src",
       "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-      "version": "1.0.41"
+      "version": "1.0.42"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-08 — Fix Friction Batch
+
+### Changed
+- QA Loop's Metric Check and Auto-Verify steps are now explicitly marked as automated — the agent runs them without pausing for confirmation, only stopping at User Testing for human approval (closes #81)
+- `/opsx:verify` now auto-fixes mechanically fixable WARNINGs (stale artifact cross-references, inconsistent naming) inline before presenting the report — judgment-required WARNINGs still require user resolution (closes #86)
+- Post-merge worktree cleanup now happens immediately after a successful merge from within a worktree — the agent switches to the main worktree, removes the completed worktree, and deletes the branch instead of leaving cleanup for the next `/opsx:new` (closes #88)
+- Consumer template `apply.instruction` synced with project WORKFLOW.md — pre-existing drift (missing "version bump" step, extra redundant verify reminder) resolved
+
+### Added
+- "Template synchronization" convention in the constitution — changes to WORKFLOW.md behavior fields must be mirrored to the consumer template at `src/templates/workflow.md` (closes #87)
+
 ## 2026-04-07 — Commit Before Approval
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ Layers are independently modifiable — WORKFLOW.md and Smart Templates do not e
 | ~~Fix sync race condition via blocking prompt and state-based validation~~ | ~~Superseded by ADR-037 — sync eliminated~~ | [ADR-036](decisions/adr-036-fix-sync-race-condition-in-archive.md) |
 | Eliminate delta specs, sync, and archive — edit specs directly, flat changes directory | Single spec format, no merge step, completion by tasks.md status not directory location | [ADR-037](decisions/adr-037-eliminate-delta-specs-sync-and-archive.md) |
 | Commit before approval in apply.instruction; WIP commit after verify, before user testing | Consistent with post_artifact pattern; WORKFLOW.md owns commit behavior; template stays clean | [ADR-038](decisions/adr-038-commit-before-approval-in-apply-instruction.md) |
+| Automated QA steps in apply.instruction; verify auto-fix for mechanical WARNINGs; template sync convention; post-merge worktree cleanup | Instruction text is the enforcement layer; mechanical auto-fix scoped narrowly; constitution owns conventions; cleanup complements lazy detection | [ADR-039](decisions/adr-039-fix-friction-batch-agent-guidance.md) |
 
 ### Notable Trade-offs
 
@@ -105,6 +106,7 @@ Layers are independently modifiable — WORKFLOW.md and Smart Templates do not e
 - **Spec conflicts on shared branches (ADR-037)**: Two parallel changes editing the same baseline spec produce git merge conflicts; mitigated by worktree isolation for local changes.
 - **Incremental docs detection depends on proposal Capabilities (ADR-037)**: Author-curated proposal may omit a capability; mitigated by manual `/opsx:docs <capability>` override and preflight traceability.
 - **More commits per change (ADR-038)**: Extra WIP implementation commit in git history; consistent with post_artifact pattern that already creates one commit per artifact. Soft enforcement via apply.instruction text.
+- **Auto-fix scope boundary is agent-judged (ADR-039)**: The distinction between "mechanically fixable" and "judgment-required" WARNINGs relies on the agent interpreting examples in the SKILL.md; edge cases may be misjudged. Mitigated by clear examples and conservative scoping.
 
 ## Conventions
 

--- a/docs/capabilities/change-workspace.md
+++ b/docs/capabilities/change-workspace.md
@@ -2,7 +2,7 @@
 title: "Change Workspace"
 capability: "change-workspace"
 description: "Create and manage change workspaces with worktree isolation and date-prefixed naming"
-lastUpdated: "2026-04-07"
+lastUpdated: "2026-04-08"
 ---
 
 # Change Workspace
@@ -26,6 +26,7 @@ Change names use kebab-case to ensure consistent, URL-safe, filesystem-safe iden
 - **Worktree context detection** -- all change-detecting skills (`ff`, `apply`, `verify`, `discover`, `preflight`) auto-detect the active change from worktree branch context before falling through to directory-based detection
 - Date-prefixed naming -- change directories use `YYYY-MM-DD-<name>` format, set at creation time for stable, chronologically sortable names
 - **Lazy worktree cleanup** -- when creating a new change, `/opsx:new` detects stale worktrees from merged PRs and cleans them up automatically
+- **Post-merge worktree cleanup** -- after a successful merge from within a worktree, the system immediately cleans up the worktree and deletes the branch instead of leaving it for the next `/opsx:new`
 - **Active vs completed detection** -- changes are distinguished by tasks.md checkbox status rather than directory location
 
 ## Behavior
@@ -49,6 +50,10 @@ The created workspace is a directory at `openspec/changes/<name>/`. The artifact
 ### Lazy Worktree Cleanup at Change Creation
 
 Before creating a new change, `/opsx:new` checks for stale worktrees. For each existing worktree, it checks the associated PR's merge status via `gh pr view`. If the PR is merged, the worktree is removed and the branch deleted. If the PR is not merged or no PR exists, the worktree is left untouched. If no stale worktrees are found, creation proceeds silently.
+
+### Post-Merge Worktree Cleanup
+
+After a successful `gh pr merge` from within a worktree, the system immediately cleans up rather than leaving stale worktrees for the next `/opsx:new`. The cleanup sequence switches to the main worktree, removes the completed worktree, and deletes the merged branch. If the worktree has uncommitted changes and removal fails, the system reports the error and suggests manual cleanup without blocking the workflow. This complements lazy cleanup -- lazy cleanup catches worktrees from merges that happened outside the agent session, while post-merge cleanup handles in-session merges immediately.
 
 ### Active vs Completed Change Detection
 

--- a/docs/capabilities/quality-gates.md
+++ b/docs/capabilities/quality-gates.md
@@ -2,7 +2,7 @@
 title: "Quality Gates"
 capability: "quality-gates"
 description: "Provides pre-implementation quality checks via /opsx:preflight, post-implementation verification via /opsx:verify, and documentation drift detection via /opsx:docs-verify."
-lastUpdated: "2026-04-07"
+lastUpdated: "2026-04-08"
 ---
 
 # Quality Gates
@@ -29,6 +29,7 @@ Preflight covers six distinct dimensions (traceability, gaps, side effects, cons
 - **Preflight Side-Effect Cross-Check**: After checking the three dimensions, verify reads `preflight.md` Section C and cross-checks each identified side-effect against task entries and codebase evidence. Unaddressed side-effects are flagged as WARNINGs.
 - **Documentation Drift Detection (`/opsx:docs-verify`)**: A check of generated documentation against current specs across three dimensions, producing a drift report with issues classified as CRITICAL, WARNING, or INFO and a verdict of CLEAN, DRIFTED, or OUT OF SYNC.
 - **Severity Classification**: Verify errs on the side of lower severity when uncertain (SUGGESTION over WARNING, WARNING over CRITICAL). Docs-verify similarly prefers INFO over WARNING when uncertain.
+- **Auto-Fix for Mechanical WARNINGs**: When verify finds WARNINGs that are mechanically fixable (stale cross-references between artifacts, inconsistent naming, outdated text correctable by simple text replacement), it fixes them inline and notes the fix in the report as "WARNING (auto-fixed)." WARNINGs that require your judgment (such as spec/design divergence) remain as open issues.
 
 ## Behavior
 
@@ -87,6 +88,14 @@ When a change has only tasks but no specs or design, verification checks task co
 #### Verification Catches Unaddressed Preflight Side-Effects
 
 After checking the three core dimensions, verify reads the preflight report's Side-Effect Analysis (Section C) and cross-checks each identified side-effect against your task list and the codebase. If a side-effect has a matching task or detectable implementation evidence, no issue is raised. If a side-effect has neither, the report includes a WARNING recommending you add a task or verify that the side-effect is handled. When all side-effects in Section C are assessed as having no risk, the cross-check is skipped and noted in the report.
+
+#### Verify Auto-Fixes Stale Cross-References
+
+When verify detects a WARNING that is mechanically fixable -- such as an artifact referencing a filename that was renamed, or inconsistent naming between artifacts -- it auto-fixes the issue inline (editing the affected file) before presenting the report. The fix appears in the report as "WARNING (auto-fixed)" so you can see what was changed, but it is not presented as an open issue requiring your action.
+
+#### Verify Does Not Auto-Fix Judgment-Required Divergences
+
+When verify detects a WARNING that requires your judgment -- such as the implementation using a different approach than the spec requires -- it does not auto-fix. The divergence is presented as an open WARNING for you to decide whether to update the spec or the code.
 
 #### Final Verify Confirms Fix Loop Resolution
 

--- a/docs/capabilities/task-implementation.md
+++ b/docs/capabilities/task-implementation.md
@@ -2,7 +2,7 @@
 title: "Task Implementation"
 capability: "task-implementation"
 description: "Handles working through task checklists in tasks.md, with sequential implementation, progress tracking, pause-on-blocker behavior, direct spec editing, standard tasks separation, and session-level progress reporting."
-lastUpdated: "2026-04-07"
+lastUpdated: "2026-04-08"
 ---
 
 # Task Implementation
@@ -26,6 +26,7 @@ Tasks are implemented sequentially in the order listed because the task list rep
 - **Direct spec editing** -- specs at `openspec/specs/` can be modified during implementation when task requirements include spec changes.
 - **Standard tasks separation** -- post-implementation steps (changelog, docs, version bump, push) are tracked as checkboxes in the task list but not executed by apply. Constitution-defined pre-merge extras are executed during the post-apply workflow. Post-merge reminders appear in a dedicated section as plain bullets — they are not tracked tasks and do not count toward progress.
 - **Parallelizable task markers** -- tasks marked with `[P]` indicate they can be done in parallel. The marker is informational only and does not change progress counting logic.
+- **Automated QA steps** -- the QA Loop's Metric Check and Auto-Verify steps run without pausing for confirmation. The first human gate is User Testing -- that is where the system stops and waits for your approval.
 
 ## Behavior
 
@@ -62,6 +63,10 @@ Every task list includes a Standard Tasks section with post-implementation workf
 Post-merge reminders (e.g., updating a plugin locally) appear in a separate "Post-Merge Reminders" section using plain bullet format — no checkboxes. They are not counted in progress totals and serve purely as visual reminders for manual execution after the PR is merged. Projects define post-merge items in the constitution's `## Standard Tasks > ### Post-Merge` section.
 
 During the post-apply workflow, universal standard task checkboxes and constitution-defined pre-merge extras (e.g., updating a PR to ready-for-review) are marked complete before creating the final commit. This ensures the committed tasks.md reflects the fully-checked state, eliminating the need for an extra follow-up commit just for checkboxes.
+
+### QA Loop Automated Steps
+
+When apply reaches the QA Loop, the Metric Check and Auto-Verify steps are executed automatically without pausing for your confirmation. The system runs each success metric check, then immediately invokes `/opsx:verify` to produce the verification report. The first point where the system stops and waits for your input is User Testing -- this is the explicit human approval gate.
 
 ### All Tasks Already Complete
 

--- a/docs/decisions/adr-039-fix-friction-batch-agent-guidance.md
+++ b/docs/decisions/adr-039-fix-friction-batch-agent-guidance.md
@@ -1,0 +1,54 @@
+# ADR-039: Fix Friction Batch — Agent Guidance Improvements
+
+## Status
+
+Accepted
+
+## Context
+
+Four friction issues (#81, #86, #87, #88) were observed in real workflow sessions where the agent either paused unnecessarily, missed auto-fixable issues, forgot to sync templates, or left stale worktrees. All four issues stemmed from gaps in instruction text — the agent followed the text literally but the text did not give clear enough guidance. The project uses convention-based enforcement (ADR-004, ADR-006, ADR-015), so the quality of instruction text directly determines agent behavior. Each fix needed to land in the correct architectural layer: `apply.instruction` in WORKFLOW.md for execution behavior, SKILL.md for command-specific guidance, and the constitution for project-wide conventions.
+
+## Decision
+
+1. **Put automated-step guidance in `apply.instruction`** — The QA Loop's Metric Check and Auto-Verify are marked as automated steps that run without pausing; the first human gate is User Testing. This belongs in `apply.instruction` because it governs apply execution behavior, not in the tasks template (which defines output format) or the apply SKILL.md (skill immutability).
+2. **Scope verify auto-fix to mechanically fixable WARNINGs** — Stale cross-references, inconsistent naming, and outdated text correctable by simple text replacement are auto-fixed inline and noted as "WARNING (auto-fixed)" in the report. Judgment-required WARNINGs (spec/design divergence) remain as open issues for user resolution. This prevents scope creep while eliminating unnecessary friction.
+3. **Add Template synchronization as a constitution convention** — Changes to WORKFLOW.md behavior fields (`apply.instruction`, `post_artifact`, `context`) must also be reflected in `src/templates/workflow.md`. The `worktree` config may intentionally differ. This is a project-level concern (two-copy pattern) that belongs in the constitution, not in a WORKFLOW.md comment or CLAUDE.md.
+4. **Put post-merge worktree cleanup in `apply.instruction`** — After a successful `gh pr merge` from within a worktree, the agent switches to the main worktree, removes the completed worktree, and deletes the branch. This extends the post-apply workflow sequence already defined in `apply.instruction`, complementing the lazy cleanup at `/opsx:new`.
+
+## Alternatives Considered
+
+| Decision | Alternative | Why Rejected |
+|----------|------------|--------------|
+| Automated-step guidance in apply.instruction | Tasks template comment | Wrong layer — template defines output format, not runtime behavior |
+| Automated-step guidance in apply.instruction | Apply SKILL.md | Skill immutability — skills must not contain project-specific behavior |
+| Verify auto-fix scoped to mechanical | Full auto-fix for all WARNINGs | Too aggressive — judgment calls must remain manual |
+| Verify auto-fix scoped to mechanical | No auto-fix (status quo) | Continues the friction that prompted #86 |
+| Template sync as constitution convention | WORKFLOW.md comment | Not visible enough during editing |
+| Template sync as constitution convention | CLAUDE.md rule | Wrong scope — CLAUDE.md is for agent instructions, not project conventions |
+| Post-merge cleanup in apply.instruction | New skill for cleanup | Overkill — cleanup is a simple 3-step sequence |
+| Post-merge cleanup in apply.instruction | Only lazy cleanup at /opsx:new | Doesn't cover in-session merges |
+
+## Consequences
+
+### Positive
+
+- The agent no longer pauses unnecessarily before running `/opsx:verify` in the QA loop
+- Trivially fixable verify WARNINGs are resolved automatically, reducing friction for the user
+- WORKFLOW.md and its consumer template stay in sync via an explicit convention
+- Worktrees are cleaned up immediately after merge instead of lingering until the next `/opsx:new`
+- Pre-existing drift between project and consumer WORKFLOW.md resolved as part of this change
+
+### Negative
+
+- Convention-based enforcement remains soft — the agent may still deviate from instruction text. This is consistent with the project's established philosophy (ADR-004, ADR-006, ADR-015).
+- The auto-fix scope boundary ("mechanically fixable" vs. "judgment-required") relies on the agent's judgment. Clear examples in the SKILL.md mitigate ambiguity.
+- `apply.instruction` grows by ~12 lines across the two additions. Still well within readable bounds.
+
+## References
+
+- [Change: fix-friction-batch](../../openspec/changes/2026-04-08-fix-friction-batch/)
+- [Spec: task-implementation](../../openspec/specs/task-implementation/spec.md)
+- [Spec: quality-gates](../../openspec/specs/quality-gates/spec.md)
+- [Spec: change-workspace](../../openspec/specs/change-workspace/spec.md)
+- [ADR-015: Smart Workflow Checkpoints](adr-015-smart-workflow-checkpoints.md)
+- [ADR-038: Commit Before Approval](adr-038-commit-before-approval-in-apply-instruction.md)

--- a/openspec/CONSTITUTION.md
+++ b/openspec/CONSTITUTION.md
@@ -36,6 +36,7 @@
 - **Workflow friction:** When workflow execution reveals friction, capture it as a GitHub Issue with the `friction` label. Include: what happened, expected behavior, and suggested fix.
 - **Design review checkpoint:** After creating specs + design artifacts, always pause for user alignment before proceeding to preflight/tasks. The design phase is the mandatory review checkpoint in every OpenSpec workflow.
 - **No ADR references in specs:** Specs MUST NOT reference ADRs (e.g., "see ADR-019"). ADRs are generated after implementation — specs exist before ADRs do. Specs describe requirements; ADRs document the decisions that shaped them.
+- **Template synchronization:** Changes to `openspec/WORKFLOW.md` behavior fields (`apply.instruction`, `post_artifact`, `context`) must also be reflected in `src/templates/workflow.md`. The `worktree` config may intentionally differ between project and consumer template (e.g., `enabled: true` in project, commented out in consumer).
 
 ## Standard Tasks
 

--- a/openspec/WORKFLOW.md
+++ b/openspec/WORKFLOW.md
@@ -18,6 +18,11 @@ apply:
     /opsx:changelog → /opsx:docs → version bump → commit → execute constitution
     pre-merge standard tasks. Never skip steps.
 
+    QA Loop automated steps: Metric Check and Auto-Verify are automated
+    steps — execute them without pausing for user confirmation. Do NOT
+    ask for permission before running /opsx:verify. The first human gate
+    is User Testing — only pause there.
+
     After /opsx:verify passes, commit and push all implementation changes
     before pausing for user approval:
     1. Stage all changed files: `git add -A`
@@ -34,6 +39,14 @@ apply:
     as complete — including the commit step itself — EXCEPT post-merge
     tasks, which remain unchecked. No extra follow-up commit should be
     needed for pre-merge standard task checkboxes.
+
+    Post-merge worktree cleanup: After a successful `gh pr merge` from
+    within a worktree, clean up immediately:
+    1. Switch working directory to the main worktree
+    2. Run `git worktree remove <worktree-path>`
+    3. Run `git branch -D <branch-name>`
+    If worktree remove fails (e.g., dirty state), report the error and
+    suggest manual cleanup — do not block the workflow.
 
 post_artifact: |
   After creating any artifact, commit and push the change:

--- a/openspec/changes/2026-04-08-fix-friction-batch/design.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/design.md
@@ -1,0 +1,57 @@
+# Technical Design: Fix Friction Batch (#81, #86, #87, #88)
+
+## Context
+
+Four friction issues from real workflow sessions need instruction-level fixes. No code changes — all fixes are text updates to WORKFLOW.md, SKILL.md, CONSTITUTION.md, and specs. The project uses convention-based enforcement (agent reads instructions and follows them), so the quality of instruction text directly determines agent behavior.
+
+## Architecture & Components
+
+| File | Change | Friction |
+|------|--------|----------|
+| `openspec/WORKFLOW.md` → `apply.instruction` | Add automated-step and post-merge cleanup guidance | #81, #88 |
+| `src/templates/workflow.md` → `apply.instruction` | Mirror the same changes (dual-update) | #81, #88 |
+| `src/skills/verify/SKILL.md` | Add auto-fix guidance for mechanically fixable WARNINGs | #86 |
+| `openspec/CONSTITUTION.md` | Add "Template synchronization" convention | #87 |
+| `src/templates/constitution.md` | Mirror new convention if template has conventions section | #87 |
+| `openspec/specs/task-implementation/spec.md` | Already updated in specs stage | #81 |
+| `openspec/specs/quality-gates/spec.md` | Already updated in specs stage | #86 |
+| `openspec/specs/change-workspace/spec.md` | Already updated in specs stage | #88 |
+
+## Goals & Success Metrics
+
+* **SM-1**: `apply.instruction` in both WORKFLOW.md files contains explicit text distinguishing automated QA steps (3.1, 3.2) from human gate (3.3) — verified by grep for "automated" or "without pausing" in `apply.instruction`
+* **SM-2**: Verify SKILL.md contains auto-fix guidance with clear scope boundary (mechanically fixable vs. judgment-required) — verified by grep for "auto-fix" in verify SKILL.md
+* **SM-3**: CONSTITUTION.md contains a "Template synchronization" convention mentioning both `openspec/WORKFLOW.md` and `src/templates/workflow.md` — verified by grep
+* **SM-4**: `apply.instruction` in both WORKFLOW.md files contains post-merge worktree cleanup sequence (switch directory → remove worktree → delete branch) — verified by grep for "worktree remove" in `apply.instruction`
+
+## Non-Goals
+
+- Hard enforcement (hooks, validation scripts) for any of these conventions
+- Changes to the tasks template structure (QA loop steps remain 3.1–3.6)
+- Changes to `/opsx:new` skill (lazy cleanup already works)
+- Modifying the preflight template or side-effect checklist
+
+## Decisions
+
+| Decision | Rationale | Alternatives |
+|----------|-----------|--------------|
+| Put automated-step guidance in `apply.instruction` (not tasks template) | `apply.instruction` is what the agent reads during execution; tasks template defines output format, not runtime behavior | Tasks template comment (wrong layer), apply SKILL.md (skill immutability) |
+| Scope verify auto-fix to "mechanically fixable" (stale references, naming) | Prevents scope creep; judgment calls (spec/design divergence) must stay manual | Full auto-fix (too aggressive), no auto-fix (status quo friction) |
+| Add "Template synchronization" as a constitution convention | Constitution owns project-specific conventions; the two-copy pattern is a project-level concern | WORKFLOW.md comment (not visible enough), CLAUDE.md rule (wrong scope) |
+| Put post-merge cleanup in `apply.instruction` | The post-apply workflow already covers commit/push/approve; post-merge is the natural next step in that sequence | New skill (overkill), `/opsx:new` only (doesn't cover in-session merges) |
+
+## Risks & Trade-offs
+
+- [Convention-based enforcement] → Mitigation: Consistent with project philosophy (ADR-004, -006, -015); instruction text is the established enforcement mechanism
+- [Consumer template divergence for worktree config] → Mitigation: The dual-update convention clarifies which fields must sync (behavior fields) vs. which may differ (worktree.enabled default)
+- [Auto-fix scope creep in verify] → Mitigation: Explicit scope boundary in SKILL.md ("stale cross-references, inconsistent naming" = auto-fix; "spec/design divergence" = manual)
+- [Post-merge cleanup from within CWD] → Mitigation: Instruction explicitly requires switching to main worktree first
+
+## Open Questions
+
+No open questions.
+
+## Assumptions
+
+- The agent reads and follows `apply.instruction` text during QA loop execution. <!-- ASSUMPTION: Agent instruction compliance -->
+- `src/templates/constitution.md` has a Conventions section where the new convention can be added. <!-- ASSUMPTION: Constitution template structure -->

--- a/openspec/changes/2026-04-08-fix-friction-batch/design.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/design.md
@@ -19,7 +19,7 @@ Four friction issues from real workflow sessions need instruction-level fixes. N
 
 ## Goals & Success Metrics
 
-* **SM-1**: `apply.instruction` in both WORKFLOW.md files contains explicit text distinguishing automated QA steps (3.1, 3.2) from human gate (3.3) — verified by grep for "automated" or "without pausing" in `apply.instruction`
+* **SM-1**: `apply.instruction` in both WORKFLOW.md files contains explicit text distinguishing automated QA steps (Metric Check, Auto-Verify) from human gate (User Testing) — verified by grep for "automated" or "without pausing" in `apply.instruction`
 * **SM-2**: Verify SKILL.md contains auto-fix guidance with clear scope boundary (mechanically fixable vs. judgment-required) — verified by grep for "auto-fix" in verify SKILL.md
 * **SM-3**: CONSTITUTION.md contains a "Template synchronization" convention mentioning both `openspec/WORKFLOW.md` and `src/templates/workflow.md` — verified by grep
 * **SM-4**: `apply.instruction` in both WORKFLOW.md files contains post-merge worktree cleanup sequence (switch directory → remove worktree → delete branch) — verified by grep for "worktree remove" in `apply.instruction`

--- a/openspec/changes/2026-04-08-fix-friction-batch/preflight.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/preflight.md
@@ -1,0 +1,63 @@
+# Pre-Flight Check: Fix Friction Batch (#81, #86, #87, #88)
+
+## A. Traceability Matrix
+
+| Capability | Requirement / Change | Scenarios | Components |
+|---|---|---|---|
+| task-implementation | Automated QA steps (#81) | QA automated steps run without pausing | `apply.instruction` in WORKFLOW.md (both copies) |
+| quality-gates | Verify auto-fix for mechanical WARNINGs (#86) | Auto-fixes stale cross-reference; Does not auto-fix judgment divergence | Verify SKILL.md |
+| change-workspace | Post-merge worktree cleanup (#88) | Cleanup after local merge; Skipped when not in worktree; Fails gracefully on dirty state | `apply.instruction` in WORKFLOW.md (both copies) |
+| (constitution convention) | Template synchronization (#87) | N/A (convention, no scenario) | CONSTITUTION.md, `src/templates/constitution.md` |
+
+All proposed changes have matching scenarios and target components. No orphaned requirements.
+
+## B. Gap Analysis
+
+- **Auto-fix boundary clarity**: The quality-gates spec defines "mechanically fixable" as "stale cross-references, inconsistent naming, outdated text correctable by simple text replacement." This is sufficiently specific — no gap.
+- **Post-merge cleanup error handling**: The change-workspace spec includes a scenario for dirty worktree failure. Covered.
+- **Template sync scope**: The constitution convention needs to clarify which WORKFLOW.md fields must sync vs. which may intentionally differ (e.g., `worktree.enabled` default). This is an implementation detail for the convention text, not a spec gap.
+
+No gaps found.
+
+## C. Side-Effect Analysis
+
+| Side-Effect | Risk | Assessment |
+|---|---|---|
+| Verify auto-fix modifies artifact files during verification | Low — only stale references; report documents each fix | Acceptable. Scope explicitly limited to mechanical fixes. |
+| apply.instruction text grows longer | Low — adding ~6 lines to an already ~20-line instruction | NONE. No functional risk. |
+| Consumer template divergence if convention not followed | Medium — the whole point of #87 is to prevent this | Addressed by the new convention itself. |
+
+No unaddressed side-effects.
+
+## D. Constitution Check
+
+- **Skill immutability**: All skill changes are to SKILL.md instruction text, not skill logic. The verify SKILL.md update adds guidance (what to do with findings), not new behavior that should live in a spec. Consistent with the three-layer architecture.
+- **README accuracy**: The README will need updating after implementation (handled by `/opsx:docs` in standard tasks).
+- **New convention needed**: #87 adds a "Template synchronization" convention to CONSTITUTION.md. This is the correct location per the architecture rules ("project-specific workflows and conventions MUST be defined in this constitution").
+
+Constitution update required: add "Template synchronization" convention. No conflicting rules.
+
+## E. Duplication & Consistency
+
+- **task-implementation vs. human-approval-gate**: The automated QA steps change is in task-implementation (where apply execution behavior lives). The human-approval-gate spec defines the approval structure and already says "Metric Check, Auto-Verify, User Testing" as the QA sequence — no contradiction. The new text says "automated steps" for the first two, which aligns with the "Auto-" prefix already in the template.
+- **change-workspace lazy cleanup vs. post-merge cleanup**: Lazy cleanup (at `/opsx:new`) and post-merge cleanup (immediate, in-session) are complementary, not duplicative. The spec explicitly states this relationship.
+- **WORKFLOW.md dual copies**: Both `openspec/WORKFLOW.md` and `src/templates/workflow.md` need the same `apply.instruction` changes. The design identifies this. The new convention (#87) formally requires this going forward.
+
+No duplication or inconsistency issues.
+
+## F. Assumption Audit
+
+| Source | Assumption | Tag | Rating |
+|---|---|---|---|
+| design.md | Agent reads and follows `apply.instruction` text during QA loop execution | Agent instruction compliance | Acceptable Risk — consistent with project enforcement philosophy (ADR-004, -006, -015) |
+| design.md | `src/templates/constitution.md` has a Conventions section | Constitution template structure | Acceptable Risk — verified: the template has `## Conventions` at line 25 |
+
+## G. Review Marker Audit
+
+No `<!-- REVIEW -->` or `<!-- REVIEW: ... -->` markers found in any artifact.
+
+---
+
+**Verdict: PASS**
+
+0 blockers, 0 warnings. All requirements traced, no gaps, no side-effect risks, no constitution conflicts, no duplication, all assumptions acceptable, no unresolved markers.

--- a/openspec/changes/2026-04-08-fix-friction-batch/proposal.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Four friction issues (#81, #86, #87, #88) reveal gaps in agent guidance that cause unnecessary pauses, missed auto-fixes, forgotten template syncs, and stale worktrees. Each issue has been observed in real workflow sessions and has a clear, low-risk fix.
+
+## What Changes
+
+- **#81:** Add explicit automated-step guidance to `apply.instruction` — QA steps 3.1 (Metric Check) and 3.2 (Auto-Verify) run without pausing; the human gate is step 3.3 (User Testing).
+- **#86:** Add auto-fix guidance to verify skill — mechanically fixable WARNINGs (stale cross-references, inconsistent text between artifacts) are resolved inline and noted in the report, instead of being presented as open issues.
+- **#87:** Add a "Template synchronization" convention to the constitution — changes to `openspec/WORKFLOW.md` behavior fields must also be reflected in `src/templates/workflow.md`.
+- **#88:** Add post-merge worktree cleanup guidance to `apply.instruction` — after successful `gh pr merge` from within a worktree, the agent switches to the main worktree, removes the completed worktree, and deletes the branch.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `quality-gates`: Add auto-fix behavior for mechanically fixable WARNINGs in the Post-Implementation Verification requirement (#86).
+- `task-implementation`: Add guidance that QA Loop steps 3.1 and 3.2 are automated (no pause before the human gate at 3.3) (#81).
+- `change-workspace`: Add post-merge worktree cleanup requirement — immediate cleanup when merge happens locally in the same session (#88).
+
+### Removed Capabilities
+
+None.
+
+### Consolidation Check
+
+N/A — no new specs proposed.
+
+Existing specs reviewed for overlap:
+- `quality-gates` — owns verify behavior, correct location for #86 auto-fix guidance
+- `task-implementation` — owns apply behavior and QA loop task processing, correct location for #81
+- `human-approval-gate` — owns QA loop structure and approval flow; #81 touches the boundary between task-implementation (what apply does with QA steps) and human-approval-gate (the approval sequence). The fix belongs in task-implementation because the issue is about apply's execution behavior, not the approval structure.
+- `change-workspace` — owns worktree lifecycle, correct location for #88 cleanup addition
+
+## Impact
+
+- **WORKFLOW.md** (`openspec/WORKFLOW.md` + `src/templates/workflow.md`): `apply.instruction` updated with automated-step and post-merge cleanup guidance
+- **Verify SKILL.md** (`src/skills/verify/SKILL.md`): Auto-fix guidance added for mechanically fixable WARNINGs
+- **CONSTITUTION.md** (`openspec/CONSTITUTION.md` + `src/templates/constitution.md`): New "Template synchronization" convention
+- **Specs**: `quality-gates`, `task-implementation`, `change-workspace` — requirement-level updates
+
+No breaking changes. No API changes. No external dependencies.
+
+## Scope & Boundaries
+
+**In scope:**
+- Instruction text updates in WORKFLOW.md `apply.instruction`
+- Verify skill guidance update
+- Constitution convention addition
+- Spec requirement updates for the three affected capabilities
+
+**Out of scope:**
+- Hard enforcement mechanisms (hooks, validation scripts)
+- Changes to the tasks template structure (the QA loop steps stay as-is)
+- Changes to the `/opsx:new` skill (lazy cleanup already works — #88 is about post-merge, not pre-creation)
+- Preflight template changes

--- a/openspec/changes/2026-04-08-fix-friction-batch/research.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/research.md
@@ -1,0 +1,71 @@
+# Research: Fix Friction Batch (#81, #86, #87, #88)
+
+## 1. Current State
+
+Four friction issues target agent guidance gaps in the apply/verify workflow and template maintenance conventions. All four are instruction-level fixes — no code changes, only spec/skill/workflow/constitution text updates.
+
+### #81 — Agent pauses before /opsx:verify
+- **Affected:** `apply.instruction` in WORKFLOW.md (both `openspec/WORKFLOW.md` and `src/templates/workflow.md`)
+- **Root cause:** The apply skill processes QA Loop tasks (3.1 Metric Check, 3.2 Auto-Verify, 3.3 User Testing) as regular pending tasks. Nothing distinguishes automated steps from human gates. The agent, uncertain whether to invoke a command autonomously, pauses to ask.
+- **Current state:** The tasks template labels step 3.2 as "Auto-Verify" — the "Auto-" prefix implies autonomous execution, but the apply skill instruction doesn't reinforce this. The `apply.instruction` in WORKFLOW.md mentions the post-apply workflow sequence but doesn't clarify which QA steps are automated vs. human-gated.
+
+### #86 — Verify reports trivially fixable WARNINGs instead of auto-fixing
+- **Affected:** Verify SKILL.md (`src/skills/verify/SKILL.md`), quality-gates spec (`openspec/specs/quality-gates/spec.md`)
+- **Root cause:** The verify skill instruction says to present all findings in a report — no distinction between WARNINGs requiring judgment and ones that are mechanically fixable (stale artifact cross-references, inconsistent naming).
+- **Current state:** Verify skill output format groups issues as CRITICAL/WARNING/SUGGESTION with recommendations. The skill never auto-fixes anything — it's purely diagnostic. The spec says "Each issue found SHALL be classified as CRITICAL, WARNING, or SUGGESTION" without auto-fix guidance.
+
+### #87 — Agent updates WORKFLOW.md but forgets consumer template
+- **Affected:** CONSTITUTION.md conventions, potentially preflight side-effect checklist
+- **Root cause:** No explicit dual-update convention exists. The constitution says "Plugin source code lives in `src/`" and "README accuracy" convention, but neither mentions the WORKFLOW.md ↔ `src/templates/workflow.md` sync requirement.
+- **Current state:** Two copies exist:
+  - `openspec/WORKFLOW.md` — project-local instance (active for this repo)
+  - `src/templates/workflow.md` — consumer template (shipped to new projects via `/opsx:setup`)
+  - These can diverge silently. The consumer template currently differs from the project version (e.g., worktree section is commented out in consumer template).
+
+### #88 — Worktree cleanup after local merge
+- **Affected:** `apply.instruction` in WORKFLOW.md, change-workspace spec (`openspec/specs/change-workspace/spec.md`)
+- **Root cause:** Lazy cleanup in `/opsx:new` only handles stale worktrees from *previously* merged PRs. When the merge happens locally in the same session (via `gh pr merge` from within the worktree), the agent leaves the worktree behind.
+- **Current state:** The `apply.instruction` covers post-apply workflow through commit/push and standard tasks, but says nothing about post-merge worktree cleanup. The change-workspace spec has "Lazy Worktree Cleanup at Change Creation" but no "immediate cleanup after merge" requirement.
+
+## 2. External Research
+
+Not applicable — all fixes are internal instruction/spec changes.
+
+## 3. Approaches
+
+| Approach | Pro | Contra |
+|----------|-----|--------|
+| A: Instruction-only fixes (WORKFLOW.md apply.instruction + verify SKILL.md + constitution convention) | Minimal change surface; consistent with project's convention-based enforcement philosophy | Soft enforcement — agent may still deviate |
+| B: Template-level changes (add auto-fix behavior to tasks template + verify template) | More structural enforcement | Templates define output format, not runtime behavior — wrong layer for these fixes |
+| C: Spec-level changes only (update specs, let skills/instructions follow) | Specs drive everything | Specs alone don't guide agent behavior — instruction text is what the agent reads during execution |
+
+**Recommended: Approach A** — with spec updates where behavior requirements change. This is consistent with how the project already works (ADR-015 "smart checkpoints", ADR-038 "commit before approval").
+
+## 4. Risks & Constraints
+
+- **Convention-based enforcement:** All four fixes rely on the agent reading and following instruction text. This is consistent with the project's philosophy (noted as a trade-off in ADR-004, ADR-006, ADR-015) but carries inherent soft-enforcement risk.
+- **Dual-update for WORKFLOW.md:** The consumer template intentionally differs from the project instance (e.g., worktree disabled by default). The dual-update convention must clarify which fields must sync vs. which may differ.
+- **Verify auto-fix scope creep:** Auto-fixing WARNINGs must be narrowly scoped to mechanically fixable issues (stale references, typos in artifact cross-references). Judgment calls (spec/design divergence) must remain reported-only.
+- **Post-merge cleanup in worktree:** The agent cannot `git worktree remove` the current working directory. Cleanup requires switching directories first — instruction must be explicit about the sequence.
+
+## 5. Coverage Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Scope | Clear | 4 friction issues with well-defined fixes |
+| Behavior | Clear | Each issue has a concrete expected behavior from the GitHub issue |
+| Data Model | Clear | No data model changes — text/instruction only |
+| UX | Clear | Agent behavior improvements, no user-facing UI changes |
+| Integration | Clear | Changes touch WORKFLOW.md, skills, constitution, specs — all internal |
+| Edge Cases | Clear | Edge cases identified per issue (worktree CWD, sync divergence, auto-fix scope) |
+| Constraints | Clear | Must respect three-layer architecture, skill immutability |
+| Terminology | Clear | Existing terms: auto-verify, human gate, consumer template |
+| Non-Functional | Clear | No performance or scalability impact |
+
+## 6. Open Questions
+
+All categories are Clear — no questions needed.
+
+## 7. Decisions
+
+No user input required — proceeding.

--- a/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
@@ -19,18 +19,18 @@
 - [x] 3.3. Metric Check: grep CONSTITUTION.md for "Template synchronization" (SM-3) — PASS
 - [x] 3.4. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "worktree remove" (SM-4) — PASS
 - [x] 3.5. Auto-Verify: Run `/opsx:verify`
-- [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
-- [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
-- [ ] 3.8. Final Verify: Run `/opsx:verify` after all fixes. Skip if 3.7 was not entered.
-- [ ] 3.9. Approval: Only finish on explicit **"Approved"** by the user.
+- [x] 3.6. User Testing: Approved by user.
+- [x] 3.7. Fix Loop: Removed unnecessary constitution template comment (consumer projects don't have src/templates/).
+- [x] 3.8. Final Verify: Run `/opsx:verify` after fix — all checks passed.
+- [x] 3.9. Approval: Approved.
 
 ## 4. Standard Tasks (Post-Implementation)
 
-- [ ] 4.1. Generate changelog (`/opsx:changelog`)
-- [ ] 4.2. Generate/update docs (`/opsx:docs`)
-- [ ] 4.3. Bump version
-- [ ] 4.4. Commit and push to remote
-- [ ] 4.5. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #81, #86, #87, #88"`)
+- [x] 4.1. Generate changelog (`/opsx:changelog`)
+- [x] 4.2. Generate/update docs (`/opsx:docs`)
+- [x] 4.3. Bump version
+- [x] 4.4. Commit and push to remote
+- [x] 4.5. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #81, #86, #87, #88"`)
 
 ## 5. Post-Merge Reminders
 

--- a/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
@@ -1,0 +1,37 @@
+# Implementation Tasks: Fix Friction Batch (#81, #86, #87, #88)
+
+## 1. Foundation
+
+- [ ] 1.1. Add "Template synchronization" convention to `openspec/CONSTITUTION.md` — changes to `openspec/WORKFLOW.md` behavior fields (`apply.instruction`, `post_artifact`, `context`) must also be reflected in `src/templates/workflow.md`. Note: `worktree` config may intentionally differ between project and consumer template.
+- [ ] 1.2. Add the same convention to `src/templates/constitution.md` under `## Conventions` (as a comment example, consistent with existing template style).
+
+## 2. Implementation
+
+- [ ] 2.1. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add automated-step guidance — Metric Check and Auto-Verify are automated steps that run without pausing; the first human gate is User Testing. (#81)
+- [ ] 2.2. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add post-merge worktree cleanup sequence — after successful `gh pr merge` from within a worktree: switch to main worktree, `git worktree remove <path>`, `git branch -D <branch>`. (#88)
+- [ ] 2.3. Mirror changes from 2.1 and 2.2 into `src/templates/workflow.md` `apply.instruction`. (#87 — applying the new convention immediately)
+- [ ] 2.4. [P] Update `src/skills/verify/SKILL.md`: add auto-fix guidance after the report generation step — mechanically fixable WARNINGs (stale cross-references, inconsistent naming between artifacts) are resolved inline before presenting the report; auto-fixed issues noted as "WARNING (auto-fixed)" in the report. Judgment-required WARNINGs remain as open issues. (#86)
+
+## 3. QA Loop & Human Approval
+
+- [ ] 3.1. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "automated" or "without pausing" (SM-1) — PASS / FAIL
+- [ ] 3.2. Metric Check: grep verify SKILL.md for "auto-fix" (SM-2) — PASS / FAIL
+- [ ] 3.3. Metric Check: grep CONSTITUTION.md for "Template synchronization" (SM-3) — PASS / FAIL
+- [ ] 3.4. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "worktree remove" (SM-4) — PASS / FAIL
+- [ ] 3.5. Auto-Verify: Run `/opsx:verify`
+- [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
+- [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
+- [ ] 3.8. Final Verify: Run `/opsx:verify` after all fixes. Skip if 3.7 was not entered.
+- [ ] 3.9. Approval: Only finish on explicit **"Approved"** by the user.
+
+## 4. Standard Tasks (Post-Implementation)
+
+- [ ] 4.1. Generate changelog (`/opsx:changelog`)
+- [ ] 4.2. Generate/update docs (`/opsx:docs`)
+- [ ] 4.3. Bump version
+- [ ] 4.4. Commit and push to remote
+- [ ] 4.5. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #81, #86, #87, #88"`)
+
+## 5. Post-Merge Reminders
+
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
+++ b/openspec/changes/2026-04-08-fix-friction-batch/tasks.md
@@ -2,23 +2,23 @@
 
 ## 1. Foundation
 
-- [ ] 1.1. Add "Template synchronization" convention to `openspec/CONSTITUTION.md` — changes to `openspec/WORKFLOW.md` behavior fields (`apply.instruction`, `post_artifact`, `context`) must also be reflected in `src/templates/workflow.md`. Note: `worktree` config may intentionally differ between project and consumer template.
-- [ ] 1.2. Add the same convention to `src/templates/constitution.md` under `## Conventions` (as a comment example, consistent with existing template style).
+- [x] 1.1. Add "Template synchronization" convention to `openspec/CONSTITUTION.md` — changes to `openspec/WORKFLOW.md` behavior fields (`apply.instruction`, `post_artifact`, `context`) must also be reflected in `src/templates/workflow.md`. Note: `worktree` config may intentionally differ between project and consumer template.
+- [x] 1.2. Add the same convention to `src/templates/constitution.md` under `## Conventions` (as a comment example, consistent with existing template style).
 
 ## 2. Implementation
 
-- [ ] 2.1. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add automated-step guidance — Metric Check and Auto-Verify are automated steps that run without pausing; the first human gate is User Testing. (#81)
-- [ ] 2.2. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add post-merge worktree cleanup sequence — after successful `gh pr merge` from within a worktree: switch to main worktree, `git worktree remove <path>`, `git branch -D <branch>`. (#88)
-- [ ] 2.3. Mirror changes from 2.1 and 2.2 into `src/templates/workflow.md` `apply.instruction`. (#87 — applying the new convention immediately)
-- [ ] 2.4. [P] Update `src/skills/verify/SKILL.md`: add auto-fix guidance after the report generation step — mechanically fixable WARNINGs (stale cross-references, inconsistent naming between artifacts) are resolved inline before presenting the report; auto-fixed issues noted as "WARNING (auto-fixed)" in the report. Judgment-required WARNINGs remain as open issues. (#86)
+- [x] 2.1. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add automated-step guidance — Metric Check and Auto-Verify are automated steps that run without pausing; the first human gate is User Testing. (#81)
+- [x] 2.2. [P] Update `openspec/WORKFLOW.md` `apply.instruction`: add post-merge worktree cleanup sequence — after successful `gh pr merge` from within a worktree: switch to main worktree, `git worktree remove <path>`, `git branch -D <branch>`. (#88)
+- [x] 2.3. Mirror changes from 2.1 and 2.2 into `src/templates/workflow.md` `apply.instruction`. (#87 — applying the new convention immediately)
+- [x] 2.4. [P] Update `src/skills/verify/SKILL.md`: add auto-fix guidance after the report generation step — mechanically fixable WARNINGs (stale cross-references, inconsistent naming between artifacts) are resolved inline before presenting the report; auto-fixed issues noted as "WARNING (auto-fixed)" in the report. Judgment-required WARNINGs remain as open issues. (#86)
 
 ## 3. QA Loop & Human Approval
 
-- [ ] 3.1. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "automated" or "without pausing" (SM-1) — PASS / FAIL
-- [ ] 3.2. Metric Check: grep verify SKILL.md for "auto-fix" (SM-2) — PASS / FAIL
-- [ ] 3.3. Metric Check: grep CONSTITUTION.md for "Template synchronization" (SM-3) — PASS / FAIL
-- [ ] 3.4. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "worktree remove" (SM-4) — PASS / FAIL
-- [ ] 3.5. Auto-Verify: Run `/opsx:verify`
+- [x] 3.1. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "automated" or "without pausing" (SM-1) — PASS
+- [x] 3.2. Metric Check: grep verify SKILL.md for "auto-fix" (SM-2) — PASS
+- [x] 3.3. Metric Check: grep CONSTITUTION.md for "Template synchronization" (SM-3) — PASS
+- [x] 3.4. Metric Check: grep `apply.instruction` in both WORKFLOW.md files for "worktree remove" (SM-4) — PASS
+- [x] 3.5. Auto-Verify: Run `/opsx:verify`
 - [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
 - [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
 - [ ] 3.8. Final Verify: Run `/opsx:verify` after all fixes. Skip if 3.7 was not entered.

--- a/openspec/specs/change-workspace/spec.md
+++ b/openspec/specs/change-workspace/spec.md
@@ -166,6 +166,36 @@ The `/opsx:new` skill SHALL check for stale worktrees before creating a new chan
 - **AND** if the branch was fully merged to main, it is deleted and the worktree removed
 - **AND** if the branch was NOT merged, `git branch -d` fails and the worktree is preserved
 
+### Requirement: Post-Merge Worktree Cleanup
+
+When a PR is merged from within a worktree (via `gh pr merge` or equivalent), the system SHALL perform immediate cleanup of the completed worktree. The cleanup sequence SHALL be: (1) switch working directory to the main worktree, (2) run `git worktree remove <path>` to remove the completed worktree, (3) run `git branch -D <branch-name>` to delete the merged branch. The system SHALL detect that it is inside a worktree by checking `git rev-parse --git-dir` for a path containing `/worktrees/`. This immediate cleanup complements lazy cleanup at `/opsx:new` — lazy cleanup catches worktrees from merges that happened outside the agent session, while immediate cleanup handles in-session merges.
+
+**User Story:** As a developer I want the worktree cleaned up immediately after my PR is merged, so that I don't have stale worktrees lingering until the next `/opsx:new`.
+
+#### Scenario: Cleanup after successful local merge
+
+- **GIVEN** the agent is working inside a worktree at `.claude/worktrees/fix-auth` on branch `fix-auth`
+- **AND** the agent runs `gh pr merge` which succeeds
+- **WHEN** the merge completes
+- **THEN** the system SHALL switch the working directory to the main worktree
+- **AND** run `git worktree remove .claude/worktrees/fix-auth`
+- **AND** run `git branch -D fix-auth`
+- **AND** report "Cleaned up worktree: fix-auth (merged)"
+
+#### Scenario: Cleanup skipped when not in worktree
+
+- **GIVEN** the agent is working in the main working tree (not a worktree)
+- **WHEN** a merge completes
+- **THEN** the system SHALL NOT attempt worktree cleanup
+
+#### Scenario: Worktree removal fails due to dirty state
+
+- **GIVEN** the agent is inside a worktree and a merge completes
+- **AND** the worktree has uncommitted changes
+- **WHEN** `git worktree remove` fails
+- **THEN** the system SHALL report the failure and suggest manual cleanup
+- **AND** SHALL NOT block the workflow
+
 ### Requirement: Active vs Completed Change Detection
 
 Skills SHALL distinguish active from completed changes based on task completion status. A change is considered **active** if its `tasks.md` contains at least one unchecked item (`- [ ]`) or if `tasks.md` does not exist (artifacts still in progress). A change is considered **completed** if its `tasks.md` exists and all items are checked (`- [x]`). Skills that operate on active changes (apply, ff, verify, discover, preflight) SHALL filter to active changes when listing available changes. Skills that operate on completed changes (changelog, docs) SHALL filter to completed changes.

--- a/openspec/specs/quality-gates/spec.md
+++ b/openspec/specs/quality-gates/spec.md
@@ -78,6 +78,8 @@ The system SHALL produce a `preflight.md` artifact containing findings and a ver
 
 The system SHALL verify the implementation against change artifacts when the user invokes `/opsx:verify`. Verification SHALL assess three dimensions: Completeness (task completion and spec coverage), Correctness (requirement implementation accuracy and scenario coverage), and Coherence (design adherence and code pattern consistency). The system SHALL read specs at `openspec/specs/<capability>/spec.md` for the capabilities listed in the change's proposal to verify implementation against. Each issue found SHALL be classified as CRITICAL (must fix before proceeding), WARNING (should fix), or SUGGESTION (nice to fix). The system SHALL produce a verification report with a summary scorecard, issues grouped by priority, and specific actionable recommendations with file and line references where applicable. The system SHALL err on the side of lower severity when uncertain (SUGGESTION over WARNING, WARNING over CRITICAL).
 
+When a WARNING is **mechanically fixable** — i.e., it involves stale cross-references between artifacts, inconsistent naming, or outdated text that can be corrected by simple text replacement without judgment — the system SHALL auto-fix the issue inline before presenting the report. Auto-fixed issues SHALL still appear in the report as resolved WARNINGs with a note indicating the fix applied. WARNINGs that require user judgment (e.g., spec/design divergence where the user must choose which is correct) SHALL NOT be auto-fixed and SHALL be presented as open issues for user resolution.
+
 The system SHALL additionally read `preflight.md` and cross-check each side-effect identified in Section C (Side-Effect Analysis) against `tasks.md` entries and codebase implementation evidence. For each side-effect, the system SHALL search for a corresponding task in `tasks.md` (keyword match) or implementation evidence in the codebase (keyword heuristic). If a side-effect has neither a matching task nor detectable implementation evidence, the system SHALL report a WARNING issue with an actionable recommendation. If Section C contains no side-effects (e.g., all risks assessed as NONE), the system SHALL skip the cross-check and note it in the report.
 
 The `/opsx:verify` command SHALL serve as both the initial verification (tasks.md step 3.2) and the final verification (step 3.5) in the QA loop. When invoked as a final verify after the fix loop, the command SHALL operate identically — checking completeness, correctness, and coherence against the current state of code and artifacts. No special flags or modes are needed; the verify skill is stateless and always checks the current state.
@@ -111,6 +113,23 @@ The `/opsx:verify` command SHALL serve as both the initial verification (tasks.m
 - **WHEN** the system checks correctness
 - **THEN** the report includes a WARNING: "Implementation may diverge from spec: auth uses session cookies, spec requires JWT"
 - **AND** recommends "Review src/auth/handler.ts:45 against requirement: JWT Authentication"
+
+#### Scenario: Verify auto-fixes stale artifact cross-reference
+
+- **GIVEN** a change where `proposal.md` references an artifact filename that was renamed during the specs stage
+- **AND** the stale reference is a simple text replacement (old filename → new filename)
+- **WHEN** the system runs `/opsx:verify`
+- **THEN** the system SHALL auto-fix the stale reference in `proposal.md`
+- **AND** the verification report SHALL list the fix as "WARNING (auto-fixed): Updated stale reference in proposal.md"
+- **AND** the report SHALL NOT present it as an open issue requiring user action
+
+#### Scenario: Verify does not auto-fix judgment-requiring divergence
+
+- **GIVEN** a spec requiring JWT authentication
+- **AND** the implementation uses session cookies instead
+- **WHEN** the system runs `/opsx:verify`
+- **THEN** the system SHALL NOT auto-fix the divergence
+- **AND** SHALL present it as an open WARNING for the user to decide whether to update the spec or the code
 
 #### Scenario: Verification finds code pattern inconsistency
 

--- a/openspec/specs/task-implementation/spec.md
+++ b/openspec/specs/task-implementation/spec.md
@@ -12,7 +12,7 @@ Handles `/opsx:apply` for working through task checklists in tasks.md, with sequ
 
 The system SHALL work through pending task checkboxes in the change's `tasks.md` file when the user invokes `/opsx:apply`. For each task, the system SHALL read the task description, make the required code changes, and mark the task as complete by changing `- [ ]` to `- [x]` in the tasks file. The system SHALL read all context files (proposal, design, tasks) from the change directory and specs from `openspec/specs/` for the capabilities listed in the proposal before beginning implementation. The system SHALL read the `apply.instruction` field from WORKFLOW.md for apply guidance. The system SHALL pause and request clarification if a task is ambiguous, if implementation reveals a design issue, or if a blocker is encountered. The system SHALL NOT guess when requirements are unclear.
 
-QA Loop steps 3.1 (Metric Check) and 3.2 (Auto-Verify) are **automated steps** — the system SHALL execute them without pausing for user confirmation. The first human gate in the QA Loop is step 3.3 (User Testing). The system SHALL NOT pause or ask for permission before running `/opsx:verify` at step 3.2; it SHALL invoke the command automatically after the metric check passes.
+The QA Loop's Metric Check and Auto-Verify steps are **automated steps** — the system SHALL execute them without pausing for user confirmation. The first human gate in the QA Loop is User Testing. The system SHALL NOT pause or ask for permission before running `/opsx:verify`; it SHALL invoke the command automatically after the metric check passes.
 
 **User Story:** As a developer I want the AI to systematically work through my task list and implement each item, so that I can focus on review and guidance rather than manual coding of each task.
 
@@ -38,11 +38,11 @@ QA Loop steps 3.1 (Metric Check) and 3.2 (Auto-Verify) are **automated steps** �
 #### Scenario: QA automated steps run without pausing
 
 - **GIVEN** a change with all implementation tasks complete
-- **AND** the system reaches QA Loop step 3.1 (Metric Check)
+- **AND** the system reaches the QA Loop Metric Check
 - **WHEN** the metric check passes
-- **THEN** the system SHALL immediately proceed to step 3.2 (Auto-Verify) without pausing
+- **THEN** the system SHALL immediately proceed to Auto-Verify without pausing
 - **AND** SHALL invoke `/opsx:verify` automatically
-- **AND** SHALL only pause at step 3.3 (User Testing) to wait for human approval
+- **AND** SHALL only pause at User Testing to wait for human approval
 
 #### Scenario: Pause on ambiguous task
 

--- a/openspec/specs/task-implementation/spec.md
+++ b/openspec/specs/task-implementation/spec.md
@@ -12,6 +12,8 @@ Handles `/opsx:apply` for working through task checklists in tasks.md, with sequ
 
 The system SHALL work through pending task checkboxes in the change's `tasks.md` file when the user invokes `/opsx:apply`. For each task, the system SHALL read the task description, make the required code changes, and mark the task as complete by changing `- [ ]` to `- [x]` in the tasks file. The system SHALL read all context files (proposal, design, tasks) from the change directory and specs from `openspec/specs/` for the capabilities listed in the proposal before beginning implementation. The system SHALL read the `apply.instruction` field from WORKFLOW.md for apply guidance. The system SHALL pause and request clarification if a task is ambiguous, if implementation reveals a design issue, or if a blocker is encountered. The system SHALL NOT guess when requirements are unclear.
 
+QA Loop steps 3.1 (Metric Check) and 3.2 (Auto-Verify) are **automated steps** — the system SHALL execute them without pausing for user confirmation. The first human gate in the QA Loop is step 3.3 (User Testing). The system SHALL NOT pause or ask for permission before running `/opsx:verify` at step 3.2; it SHALL invoke the command automatically after the metric check passes.
+
 **User Story:** As a developer I want the AI to systematically work through my task list and implement each item, so that I can focus on review and guidance rather than manual coding of each task.
 
 #### Scenario: Implement all tasks sequentially
@@ -32,6 +34,15 @@ The system SHALL work through pending task checkboxes in the change's `tasks.md`
 - **THEN** the system skips the 3 already-completed tasks
 - **AND** begins working from the first pending task (task 4 of 7)
 - **AND** displays "3/7 tasks already complete, continuing from task 4"
+
+#### Scenario: QA automated steps run without pausing
+
+- **GIVEN** a change with all implementation tasks complete
+- **AND** the system reaches QA Loop step 3.1 (Metric Check)
+- **WHEN** the metric check passes
+- **THEN** the system SHALL immediately proceed to step 3.2 (Auto-Verify) without pausing
+- **AND** SHALL invoke `/opsx:verify` automatically
+- **AND** SHALL only pause at step 3.3 (User Testing) to wait for human approval
 
 #### Scenario: Pause on ambiguous task
 

--- a/src/.claude-plugin/plugin.json
+++ b/src/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx",
   "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "author": {
     "name": "fritze.dev"
   },

--- a/src/skills/verify/SKILL.md
+++ b/src/skills/verify/SKILL.md
@@ -139,6 +139,17 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    | Side-Effects   | N checked, M unaddressed |
    ```
 
+   **Auto-Fix Pass** (before presenting the report):
+
+   Before generating the final report, scan all WARNING-level findings
+   for mechanically fixable issues — stale cross-references between
+   artifacts, inconsistent naming, or outdated text correctable by
+   simple text replacement without judgment. Auto-fix these inline
+   (edit the affected file) and record them as "WARNING (auto-fixed)"
+   in the report. Do NOT auto-fix WARNINGs that require user judgment
+   (e.g., spec/design divergence where the user must choose which is
+   correct) — present those as open issues.
+
    **Issues by Priority**:
 
    1. **CRITICAL** (Must fix before proceeding):
@@ -151,6 +162,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
       - Missing scenario coverage
       - Unaddressed preflight side-effects
       - Each with specific recommendation
+      - Auto-fixed warnings listed separately as "WARNING (auto-fixed)"
 
    3. **SUGGESTION** (Nice to fix):
       - Pattern inconsistencies

--- a/src/templates/constitution.md
+++ b/src/templates/constitution.md
@@ -24,9 +24,6 @@ instruction: |
 
 ## Conventions
 (Naming, commits, branching, file organization)
-<!-- Template synchronization: changes to openspec/WORKFLOW.md behavior fields
-     (apply.instruction, post_artifact, context) must also be reflected in
-     src/templates/workflow.md. Worktree config may intentionally differ. -->
 
 ## Standard Tasks
 

--- a/src/templates/constitution.md
+++ b/src/templates/constitution.md
@@ -24,6 +24,9 @@ instruction: |
 
 ## Conventions
 (Naming, commits, branching, file organization)
+<!-- Template synchronization: changes to openspec/WORKFLOW.md behavior fields
+     (apply.instruction, post_artifact, context) must also be reflected in
+     src/templates/workflow.md. Worktree config may intentionally differ. -->
 
 ## Standard Tasks
 

--- a/src/templates/workflow.md
+++ b/src/templates/workflow.md
@@ -15,10 +15,8 @@ apply:
 
     Post-apply workflow: /opsx:verify → commit and push implementation
     changes for review → pause for user approval →
-    /opsx:changelog → /opsx:docs → commit → execute constitution
+    /opsx:changelog → /opsx:docs → version bump → commit → execute constitution
     pre-merge standard tasks. Never skip steps.
-    IMPORTANT: /opsx:verify MUST run before proceeding.
-    Never proceed before implementation is verified.
 
     QA Loop automated steps: Metric Check and Auto-Verify are automated
     steps — execute them without pausing for user confirmation. Do NOT

--- a/src/templates/workflow.md
+++ b/src/templates/workflow.md
@@ -20,6 +20,11 @@ apply:
     IMPORTANT: /opsx:verify MUST run before proceeding.
     Never proceed before implementation is verified.
 
+    QA Loop automated steps: Metric Check and Auto-Verify are automated
+    steps — execute them without pausing for user confirmation. Do NOT
+    ask for permission before running /opsx:verify. The first human gate
+    is User Testing — only pause there.
+
     After /opsx:verify passes, commit and push all implementation changes
     before pausing for user approval:
     1. Stage all changed files: `git add -A`
@@ -36,6 +41,14 @@ apply:
     as complete — including the commit step itself — EXCEPT post-merge
     tasks, which remain unchecked. No extra follow-up commit should be
     needed for pre-merge standard task checkboxes.
+
+    Post-merge worktree cleanup: After a successful `gh pr merge` from
+    within a worktree, clean up immediately:
+    1. Switch working directory to the main worktree
+    2. Run `git worktree remove <worktree-path>`
+    3. Run `git branch -D <branch-name>`
+    If worktree remove fails (e.g., dirty state), report the error and
+    suggest manual cleanup — do not block the workflow.
 
 post_artifact: |
   After creating any artifact, commit and push the change:


### PR DESCRIPTION
## Summary

Batch fix for 4 friction issues observed in real workflow sessions:

- **#81** — QA Loop's Metric Check and Auto-Verify are now explicitly automated steps; agent no longer pauses before `/opsx:verify`
- **#86** — `/opsx:verify` auto-fixes mechanically fixable WARNINGs (stale cross-references, inconsistent naming) inline before presenting the report
- **#87** — New "Template synchronization" convention in constitution; pre-existing drift between project and consumer WORKFLOW.md resolved
- **#88** — Post-merge worktree cleanup happens immediately after `gh pr merge` from within a worktree

## Changes

- `openspec/WORKFLOW.md` + `src/templates/workflow.md`: `apply.instruction` updated with automated QA step guidance and post-merge worktree cleanup
- `src/skills/verify/SKILL.md`: Auto-fix pass added before report generation
- `openspec/CONSTITUTION.md`: Template synchronization convention added
- 3 specs updated: task-implementation, quality-gates, change-workspace
- ADR-039, capability docs, README, changelog updated

Closes #81, Closes #86, Closes #87, Closes #88