### PR TITLE
Custom Actions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "opsx",
       "source": "./src",
       "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-10 — Custom Actions (v2.0.1)
+
+### Added
+- Consumer-defined custom actions in WORKFLOW.md — projects can extend the workflow by adding action names to the `actions` array and providing `## Action: <name>` body sections with self-contained instructions
+- Generic fallback dispatch in the router — custom actions are validated against the `actions` array and executed directly, with the agent deciding whether to handle inline or spawn a sub-agent
+- Graceful degradation when WORKFLOW.md is missing — the router falls back to the 4 built-in actions (init, propose, apply, finalize) so that init works without a pre-existing WORKFLOW.md
+
+### Changed
+- Router Step 1 now validates actions dynamically against the `actions` array from WORKFLOW.md instead of a hardcoded list
+- CONSTITUTION.md Architecture Rules updated from "4 actions" to "4 built-in actions + consumer-defined custom actions"
+- Consumer WORKFLOW.md template includes a comment explaining custom action usage
+
 ## 2026-04-09 — Skill Consolidation (v2.0.0)
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The opsx-enhanced plugin uses a **three-layer architecture** where each layer ha
 
 2. **WORKFLOW.md + Smart Templates** (`openspec/WORKFLOW.md` + `openspec/templates/`) -- WORKFLOW.md declares the 7-stage artifact pipeline order, inline action definitions, apply gate, optional worktree configuration, automation config, and project context in YAML frontmatter. Smart Templates in `openspec/templates/` carry per-artifact instructions, output paths, dependencies, and `template-version` for merge detection in YAML frontmatter alongside the output structure. Together they are the single source of truth for pipeline structure, action instructions, and artifact generation.
 
-3. **Router + Actions** (`skills/workflow/SKILL.md`) -- A single router skill dispatches to 4 actions: `init` (project setup and health checks), `propose` (pipeline traversal), `apply` (task implementation with review.md), and `finalize` (changelog, docs, version bump). The router handles shared orchestration (intent recognition, change context detection, WORKFLOW.md loading) and spawns sub-agents with bounded context for each action. All actions are model-invocable.
+3. **Router + Actions** (`skills/workflow/SKILL.md`) -- A single router skill dispatches to 4 built-in actions: `init` (project setup and health checks), `propose` (pipeline traversal), `apply` (task implementation with review.md), and `finalize` (changelog, docs, version bump), plus consumer-defined custom actions. The router handles shared orchestration (intent recognition, change context detection, WORKFLOW.md loading) and spawns sub-agents with bounded context for built-in actions. Custom actions are validated against the `actions` array in WORKFLOW.md and executed directly. All actions are model-invocable.
 
 Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not embed router logic, the router depends on them by reading WORKFLOW.md and templates directly at runtime, and the constitution does not contain pipeline-specific artifact definitions.
 
@@ -66,6 +66,7 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 | Automated QA steps in apply.instruction; verify auto-fix for mechanical WARNINGs; template sync convention; post-merge worktree cleanup | Instruction text is the enforcement layer; mechanical auto-fix scoped narrowly; constitution owns conventions; cleanup complements lazy detection | [ADR-039](decisions/adr-039-fix-friction-batch-agent-guidance.md) |
 | Spec frontmatter tracking with structured metadata across specs, proposals, designs, and templates | Eliminates fragile markdown parsing; enables collision detection, incremental detection via lastModified, and version-aware template merge on re-setup | [ADR-040](decisions/adr-040-spec-frontmatter-tracking.md) |
 | Consolidate 11 SKILL.md files to 1 router with 4 commands; inline actions in WORKFLOW.md; review.md as pipeline artifact | 93% orchestration code reduction; specs as true single source of truth; persistent PR-visible verification | [ADR-041](decisions/adr-041-skill-consolidation.md) |
+| Generic fallback dispatch for custom actions; direct execution; dynamic validation against actions array | Minimizes change surface (propose can't be generalized); avoids sub-agent nesting; graceful degradation without WORKFLOW.md | [ADR-042](decisions/adr-042-custom-action-dispatch-design.md) |
 
 ### Notable Trade-offs
 
@@ -114,6 +115,8 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 - **Breaking change for consumers (ADR-041)**: Consumers on template-version 1 must run `/opsx:workflow init` to migrate to template-version 3. Mitigated by init handling the migration.
 - **Plugin stub indirection (ADR-041)**: Extra file-read between command invocation and router logic. Mitigated by stubs being trivially simple (~5 lines each).
 - **Loss of standalone preflight/verify commands (ADR-041)**: Users must go through propose or apply. Accepted because 4-command sufficiency covers all workflow needs.
+- **Custom action instruction quality (ADR-042)**: No spec requirement links for custom actions -- instruction quality depends entirely on the consumer author. Mitigated by clear documentation and the self-contained instruction pattern.
+- **Change context for all custom actions (ADR-042)**: Change context detection runs for every custom action even if not needed; the instruction must handle that case explicitly.
 
 ## Conventions
 
@@ -131,7 +134,7 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 
 | Capability | Description |
 |---|---|
-| [Workflow Contract](capabilities/workflow-contract.md) | WORKFLOW.md pipeline orchestration, Smart Templates, inline actions, and router dispatch |
+| [Workflow Contract](capabilities/workflow-contract.md) | WORKFLOW.md pipeline orchestration, Smart Templates, inline actions, custom actions, and router dispatch |
 | [Three-Layer Architecture](capabilities/three-layer-architecture.md) | Constitution, WORKFLOW.md + Smart Templates, and Router + Actions with independent modifiability |
 | [Spec Format](capabilities/spec-format.md) | Format rules for specs with normative descriptions, Gherkin scenarios, and frontmatter tracking |
 | [Roadmap Tracking](capabilities/roadmap-tracking.md) | Planned improvements tracked as GitHub Issues with a roadmap label |

--- a/docs/capabilities/three-layer-architecture.md
+++ b/docs/capabilities/three-layer-architecture.md
@@ -15,14 +15,14 @@ Projects using AI-driven workflows need a way to separate global rules, pipeline
 
 ## Rationale
 
-Separating concerns into Constitution (project rules), WORKFLOW.md + Smart Templates (pipeline structure and artifact definitions), and Router + Actions (command dispatch) ensures each layer has a single authoritative owner. WORKFLOW.md provides slim pipeline orchestration -- stage ordering, apply gate, inline action definitions, optional worktree configuration -- while Smart Templates carry their own instructions and metadata in YAML frontmatter. The third layer consolidated from 11 separate skill files to a single router that dispatches to 4 actions (init, propose, apply, finalize), eliminating 90%+ of orchestration code duplication. Actions are defined inline in WORKFLOW.md, making the router a thin dispatcher that reads WORKFLOW.md dynamically at runtime.
+Separating concerns into Constitution (project rules), WORKFLOW.md + Smart Templates (pipeline structure and artifact definitions), and Router + Actions (command dispatch) ensures each layer has a single authoritative owner. WORKFLOW.md provides slim pipeline orchestration -- stage ordering, apply gate, inline action definitions, optional worktree configuration -- while Smart Templates carry their own instructions and metadata in YAML frontmatter. The third layer consolidated from 11 separate skill files to a single router that dispatches to 4 built-in actions (init, propose, apply, finalize) plus consumer-defined custom actions, eliminating 90%+ of orchestration code duplication. Actions are defined inline in WORKFLOW.md, making the router a thin dispatcher that reads WORKFLOW.md dynamically at runtime. Custom actions leverage the same layer separation -- they are defined in WORKFLOW.md (Layer 2) and dispatched by the router (Layer 3) without requiring changes to either the router or the constitution.
 
 ## Features
 
 - **Constitution Layer**: A single `CONSTITUTION.md` file at `openspec/CONSTITUTION.md` defines all project-wide rules, including Tech Stack, Architecture Rules, Code Style, Constraints, and Conventions. Every AI action reads this file before performing work, enforced via WORKFLOW.md's `context` field.
-- **WORKFLOW.md + Smart Templates Layer**: `openspec/WORKFLOW.md` declares the 7-stage artifact pipeline order, inline action definitions, apply gate, optional worktree configuration, automation config, and project context. Smart Templates in `openspec/templates/` carry per-artifact instructions, output paths, and dependencies in YAML frontmatter. Together they serve as the single source of truth for pipeline structure, action instructions, and artifact generation.
-- **Router + Actions Layer**: All commands are delivered through a single router SKILL.md that dispatches to 4 actions: `init` (project setup and health checks), `propose` (pipeline traversal), `apply` (task implementation with review.md), and `finalize` (changelog, docs, version bump). The router is model-invocable.
-- **Layer Separation**: Each layer is independently modifiable. WORKFLOW.md and Smart Templates do not embed router logic, and the constitution does not contain pipeline-specific definitions. The router depends on WORKFLOW.md and Smart Templates by reading them directly at runtime.
+- **WORKFLOW.md + Smart Templates Layer**: `openspec/WORKFLOW.md` declares the 7-stage artifact pipeline order, inline action definitions (built-in and custom), apply gate, optional worktree configuration, automation config, and project context. Smart Templates in `openspec/templates/` carry per-artifact instructions, output paths, and dependencies in YAML frontmatter. Together they serve as the single source of truth for pipeline structure, action instructions, and artifact generation.
+- **Router + Actions Layer**: All commands are delivered through a single router SKILL.md that dispatches to 4 built-in actions: `init` (project setup and health checks), `propose` (pipeline traversal), `apply` (task implementation with review.md), and `finalize` (changelog, docs, version bump). The router additionally supports consumer-defined custom actions listed in the WORKFLOW.md `actions` array. The router is model-invocable.
+- **Layer Separation**: Each layer is independently modifiable. WORKFLOW.md and Smart Templates do not embed router logic, and the constitution does not contain pipeline-specific definitions. The router depends on WORKFLOW.md and Smart Templates by reading them directly at runtime. Adding a custom action requires only WORKFLOW.md changes -- no router or constitution modifications.
 
 ## Behavior
 
@@ -32,15 +32,19 @@ The constitution file is loaded and its rules are applied before any AI-driven a
 
 ### WORKFLOW.md and Smart Templates Define the Pipeline and Actions
 
-WORKFLOW.md declares 7 artifacts in strict dependency order via its `pipeline` array: research, proposal, specs, design, preflight, tasks, and review. It also defines inline actions (init, propose, apply, finalize) with `## Action: <name>` body sections containing procedural instructions. Each Smart Template contains `id`, `generates`, `requires`, and `instruction` fields. The apply phase is gated by the tasks artifact.
+WORKFLOW.md declares 7 artifacts in strict dependency order via its `pipeline` array: research, proposal, specs, design, preflight, tasks, and review. It also defines inline actions (built-in and custom) with `## Action: <name>` body sections containing procedural instructions. Each Smart Template contains `id`, `generates`, `requires`, and `instruction` fields. The apply phase is gated by the tasks artifact.
 
-### Router Dispatches to 4 Actions
+### Router Dispatches to Built-in and Custom Actions
 
-A single router SKILL.md handles all user-facing commands. It performs shared orchestration (intent recognition, change context detection, WORKFLOW.md loading) and dispatches to the appropriate action. For propose, it traverses the pipeline. For apply and finalize, it spawns a sub-agent with bounded context. For init, it executes without change context.
+A single router SKILL.md handles all user-facing commands. It performs shared orchestration (intent recognition, change context detection, WORKFLOW.md loading) and dispatches to the appropriate action. For propose, it traverses the pipeline. For apply and finalize, it spawns a sub-agent with bounded context. For init, it executes without change context. For custom actions, it reads the instruction from WORKFLOW.md and executes it directly, with the agent deciding the execution mode.
+
+### Adding Custom Actions Does Not Require Router Changes
+
+A consumer adds a custom action by appending it to the `actions` array in WORKFLOW.md frontmatter and writing a `## Action: <name>` body section. The router validates against the `actions` array dynamically and dispatches via a generic fallback -- no modification to the router SKILL.md is needed.
 
 ### Layers Are Independently Modifiable
 
-Updating a WORKFLOW.md action instruction does not require changes to the router, because the router reads WORKFLOW.md dynamically. Adding a new code style rule to the constitution does not require WORKFLOW.md changes. Refining the router's dispatch logic does not require changes to the constitution or WORKFLOW.md.
+Updating a WORKFLOW.md action instruction does not require changes to the router, because the router reads WORKFLOW.md dynamically. Adding a new code style rule to the constitution does not require WORKFLOW.md changes. Refining the router's dispatch logic does not require changes to the constitution or WORKFLOW.md. Adding a custom action only touches WORKFLOW.md.
 
 ## Known Limitations
 

--- a/docs/capabilities/workflow-contract.md
+++ b/docs/capabilities/workflow-contract.md
@@ -1,7 +1,7 @@
 ---
 title: "Workflow Contract"
 capability: "workflow-contract"
-description: "WORKFLOW.md pipeline orchestration, Smart Templates, inline actions, and router dispatch pattern"
+description: "WORKFLOW.md pipeline orchestration, Smart Templates, inline actions, custom actions, and router dispatch"
 lastUpdated: "2026-04-10"
 ---
 
@@ -15,20 +15,21 @@ Without a standardized contract format, pipeline configuration scatters across m
 
 ## Rationale
 
-A slim WORKFLOW.md handles pipeline orchestration (stage ordering, apply gate, project context) while Smart Templates handle artifact definitions (instruction, output path, dependencies). Actions are defined inline in WORKFLOW.md because they have no output structure -- separate action template files (as explored in PR #97) add maintenance overhead without benefit. The router dispatch pattern consolidates 11 separate skill files into a single router that reads WORKFLOW.md dynamically, eliminating copy-pasted logic like change context detection. Both WORKFLOW.md and Smart Templates include a `template-version` field (integer) that enables `/opsx:workflow init` to detect user customizations and merge plugin updates instead of overwriting.
+A slim WORKFLOW.md handles pipeline orchestration (stage ordering, apply gate, project context) while Smart Templates handle artifact definitions (instruction, output path, dependencies). Actions are defined inline in WORKFLOW.md because they have no output structure -- separate action template files (as explored in PR #97) add maintenance overhead without benefit. The router dispatch pattern consolidates 11 separate skill files into a single router that reads WORKFLOW.md dynamically, eliminating copy-pasted logic like change context detection. Both WORKFLOW.md and Smart Templates include a `template-version` field (integer) that enables `/opsx:workflow init` to detect user customizations and merge plugin updates instead of overwriting. Custom actions extend this system by allowing consumer projects to add their own actions to the `actions` array without modifying the plugin source.
 
 ## Features
 
 - **WORKFLOW.md pipeline orchestration** -- YAML frontmatter with `templates_dir`, `pipeline` array (7 stages), `actions` array, `template-version`, optional `worktree`, `auto_approve`, `automation`, and `docs_language`; markdown body with `## Context` and `## Action: <name>` sections
 - **Smart Template format** -- each template carries `id`, `description`, `generates`, `requires`, `instruction`, and `template-version` fields in YAML frontmatter, with the output structure as the markdown body
-- **Inline action definitions** -- `actions` array in frontmatter lists action names; each action has a `## Action: <name>` body section with `### Instruction` for procedural guidance
-- **Router dispatch pattern** -- single router handles all 4 commands (init, propose, apply, finalize) with shared intent recognition, change context detection, and WORKFLOW.md loading
+- **Inline action definitions** -- `actions` array in frontmatter lists action names (built-in and custom); each action has a `## Action: <name>` body section with `### Instruction` for procedural guidance
+- **Custom actions** -- consumer projects define additional actions by adding names to the `actions` array and writing corresponding `## Action: <name>` body sections with self-contained instructions; no plugin modification required
+- **Router dispatch pattern** -- single router handles all commands (built-in and custom) with shared intent recognition, change context detection, and WORKFLOW.md loading; validates actions against the `actions` array with fallback to built-in list
 - **Automation configuration** -- optional `automation.post_approval` section configures CI-triggered finalize on PR approval with state labels
 - **Template versioning** -- `template-version` (integer, monotonically increasing) enables version-aware merge during `/opsx:workflow init`
 
 ## Behavior
 
-### WORKFLOW.md Provides Pipeline and Action Configuration
+### WORKFLOW.MD Provides Pipeline and Action Configuration
 
 The router reads WORKFLOW.md's YAML frontmatter to determine the template directory, pipeline stage order, available actions, and optional automation config. The markdown body provides the `## Context` section for project-level behavioral context and `## Action: <name>` sections with procedural instructions for each action.
 
@@ -36,13 +37,17 @@ The router reads WORKFLOW.md's YAML frontmatter to determine the template direct
 
 Each template file contains everything needed to generate its artifact: the `instruction` field provides behavioral constraints for the AI, the `generates` field specifies where the output goes, `requires` lists dependency artifacts, and the markdown body defines the output structure. The `instruction` content is never copied into generated artifacts -- it serves only as generation-time constraints.
 
-### Actions Are Defined Inline in WORKFLOW.md
+### Built-in Actions Use Requirement Links from SKILL.md
 
-Each action has a `## Action: <name>` section in the WORKFLOW.md body containing `### Instruction` with procedural guidance. Requirement links (clickable markdown links to spec requirements) live in the SKILL.md file for each action, not in WORKFLOW.md. When executing an action, the router reads the instruction from WORKFLOW.md and the requirement links from SKILL.md, loads the referenced requirements from specs, and spawns a sub-agent with bounded context.
+Each built-in action (init, propose, apply, finalize) has a `## Action: <name>` section in the WORKFLOW.md body containing `### Instruction` with procedural guidance. Requirement links (clickable markdown links to spec requirements) live in the SKILL.md file, not in WORKFLOW.md. When executing a built-in action, the router reads the instruction from WORKFLOW.md and the requirement links from SKILL.md, loads the referenced requirements from specs, and spawns a sub-agent with bounded context.
 
-### Router Dispatches All Commands
+### Custom Actions Execute Instructions Directly
 
-The single router handles intent recognition, change context detection (proposal frontmatter lookup, worktree fallback, directory listing fallback), WORKFLOW.md loading, and dispatch. For `propose`, it traverses the pipeline. For `apply` and `finalize`, it reads the action definition and spawns a sub-agent. For `init`, it executes directly without change context.
+Custom actions listed in the `actions` array have their `## Action: <name>` sections read by the router, which executes the instruction directly. The executing agent decides whether to handle it inline or spawn a sub-agent based on the instruction content. Custom actions do not receive spec requirement links -- their instruction text is self-contained. Custom actions go through change context detection (like apply/finalize), enabling them to operate on the current change.
+
+### Router Validates Actions Dynamically
+
+The router validates the invoked command against the `actions` array from WORKFLOW.md frontmatter. If WORKFLOW.md is missing (pre-init), the router falls back to the 4 built-in actions. If the action is not recognized, the router reports the error and lists available actions.
 
 ### Automation Configuration
 
@@ -53,12 +58,15 @@ The optional `automation.post_approval` section defines what happens when a PR r
 - YAML frontmatter parsing depends on Claude's native ability to interpret YAML in markdown files.
 - The `template-version` field is only used by init for merge detection; the router ignores it at runtime.
 - Sub-agents spawned via the Agent tool do not receive the router's full conversation history.
+- Custom action instruction quality depends on the author -- if the instruction is vague, execution may underperform.
 
 ## Edge Cases
 
-- If WORKFLOW.md is missing, the router reports an error and suggests running `/opsx:workflow init`.
+- If WORKFLOW.md is missing, the router reports an error and suggests running `/opsx:workflow init`. For action validation, it falls back to the built-in actions list.
 - If a Smart Template lacks YAML frontmatter, the router treats it as a plain template with no instruction or metadata and reports a warning.
 - If a Smart Template is missing the `template-version` field, init treats it as version 0 (always eligible for update).
 - If WORKFLOW.md contains malformed YAML, the router reports a parse error and stops.
 - If the `pipeline` array is empty, the router reports that no artifacts are defined and stops.
-- If an action name does not match a defined action, the router reports the error and lists available actions.
+- If an action name does not match any entry in the `actions` array, the router reports the error and lists available actions.
+- If a custom action is listed in the `actions` array but has no corresponding `## Action: <name>` body section, the router reports the missing instruction and stops.
+- Custom actions go through change context detection; if a custom action does not need change context, the instruction text should handle that.

--- a/docs/decisions/adr-042-custom-action-dispatch-design.md
+++ b/docs/decisions/adr-042-custom-action-dispatch-design.md
@@ -1,0 +1,49 @@
+# ADR-042: Custom Action Dispatch Design
+
+## Status
+
+Accepted (2026-04-10)
+
+## Context
+
+The router SKILL.md hardcodes 4 actions in Step 1 (validation) and Step 5 (dispatch). The `actions` array in WORKFLOW.md frontmatter is read but not used for validation -- it is ignored in favor of a hardcoded list. Consumer projects need to define their own workflow actions (e.g., QA review, deployment, linting) without modifying the plugin source. Three of the four built-in dispatch patterns (apply, finalize, init) already follow the identical Sub-Agent Execution pattern. The `propose` action is fundamentally different because it uses Pipeline Traversal logic. Opening the actions system to consumer-defined actions requires decisions about validation strategy, dispatch mechanism, execution mode, and change context handling.
+
+## Decision
+
+1. **Add a generic fallback in Step 5 rather than refactoring all 4 built-in actions** -- Minimizes change surface. The `propose` action has unique Pipeline Traversal logic that cannot be generalized, and built-in actions have requirement links that custom actions do not need. A fallback block after the built-in dispatch handles any action not in `[init, propose, apply, finalize]`.
+
+2. **Execute custom action instructions directly instead of forcing a sub-agent** -- Custom actions may invoke skills that spawn their own sub-agents. Forcing a router-level sub-agent would cause unnecessary nesting and constrain custom action authors. The executing agent decides whether to handle inline or spawn a sub-agent based on the instruction content.
+
+3. **Custom actions go through change context detection** -- Most custom actions operate on a change (QA review, deploy, lint). Actions that do not need change context can handle this in their instruction text, the same way `init` is explicitly excluded.
+
+4. **Validate against the `actions` array, fall back to built-in list if WORKFLOW.md is missing** -- Graceful degradation for projects without WORKFLOW.md (pre-init). Hard-requiring WORKFLOW.md was rejected because `init` needs to work without it.
+
+## Alternatives Considered
+
+- Refactor all 4 actions into a single generic dispatch -- rejected because `propose` is fundamentally different (Pipeline Traversal vs. Sub-Agent Execution)
+- Always spawn a sub-agent for custom actions -- rejected because it constrains custom action authors and causes unnecessary double-nesting when the instruction itself invokes skills with sub-agents
+- Skip change context detection for custom actions -- rejected because most custom actions operate on a change and would lose access to useful context
+- Hard-require WORKFLOW.md for all invocations -- rejected because `init` needs to work without it to bootstrap a project
+
+## Consequences
+
+### Positive
+
+- Consumer projects can define custom workflow actions without modifying the plugin source
+- Adding a custom action requires only WORKFLOW.md changes (adding to `actions` array + writing `## Action: <name>` section), preserving layer separation
+- All 4 built-in actions retain their exact current behavior -- zero regression
+- The router validates custom actions against the `actions` array, providing clear error messages for typos or missing actions
+- Custom actions get full change context, enabling them to operate on the current change directory and branch
+
+### Negative
+
+- Custom action instruction quality depends entirely on the author -- the router provides no spec requirement links, so vague instructions may lead to poor execution
+- Change context detection runs for all custom actions even if an action does not need it; the instruction must explicitly handle that case
+- The generic fallback is a new code path that could diverge from built-in dispatch patterns over time
+
+## References
+
+- [Change: 2026-04-10-custom-actions](../../openspec/changes/2026-04-10-custom-actions/)
+- [Spec: workflow-contract](../../openspec/specs/workflow-contract/spec.md)
+- [Spec: three-layer-architecture](../../openspec/specs/three-layer-architecture/spec.md)
+- [ADR-041: Skill Consolidation](adr-041-skill-consolidation.md)

--- a/openspec/CONSTITUTION.md
+++ b/openspec/CONSTITUTION.md
@@ -12,7 +12,7 @@ template-version: 1
 
 ## Architecture Rules
 
-- **Three-layer architecture:** CONSTITUTION.md (global rules) → WORKFLOW.md + Smart Templates (artifact pipeline + inline actions) → Router (single workflow skill with 4 actions: init, propose, apply, finalize)
+- **Three-layer architecture:** CONSTITUTION.md (global rules) → WORKFLOW.md + Smart Templates (artifact pipeline + inline actions) → Router (single workflow skill with 4 built-in actions (init, propose, apply, finalize) + consumer-defined custom actions)
 - Layers are independently modifiable — WORKFLOW.md and Smart Templates do not embed router logic, the router depends on them via direct file reads
 - **Router immutability:** The workflow skill (`skills/workflow/SKILL.md`) is generic plugin code shared across all consumers. They MUST NOT be modified for project-specific behavior. Project-specific workflows and conventions MUST be defined in this constitution.
 - Plugin manifests live in `.claude-plugin/` (plugin.json, marketplace.json)

--- a/openspec/changes/2026-04-10-custom-actions/design.md
+++ b/openspec/changes/2026-04-10-custom-actions/design.md
@@ -1,0 +1,65 @@
+---
+has_decisions: true
+---
+# Technical Design: Custom Actions
+
+## Context
+
+The router SKILL.md currently hardcodes 4 actions in Step 1 (validation) and Step 5 (dispatch). The `actions` array in WORKFLOW.md frontmatter is read but not used for validation. Three of the four dispatch patterns (apply, finalize, init) already follow the identical Sub-Agent Execution pattern. The change opens the actions system so consumer projects can define additional actions via WORKFLOW.md alone.
+
+## Architecture & Components
+
+**Files affected:**
+
+| File | Change |
+|------|--------|
+| `src/skills/workflow/SKILL.md` | Step 1: dynamic validation from `actions` array. Step 5: generic fallback block for custom actions. |
+| `src/templates/workflow.md` | Add comment explaining custom actions in frontmatter. |
+
+**Dispatch flow for custom actions:**
+
+```
+User: /opsx:workflow qa-review
+  → Router Step 1: validate "qa-review" ∈ actions array from WORKFLOW.md ✓
+  → Router Step 2: load WORKFLOW.md (already happens)
+  → Router Step 3: change context detection (same as apply/finalize)
+  → Router Step 4: read ## Action: qa-review → ### Instruction (no requirement links)
+  → Router Step 5: generic fallback → spawn sub-agent with instruction + change context
+```
+
+**No new files, no new concepts.** The generic fallback reuses the existing Sub-Agent Execution pattern used by apply/finalize/init.
+
+## Goals & Success Metrics
+
+- Built-in actions (init, propose, apply, finalize) behave identically to before — zero regression
+- Custom action defined in `actions` array + `## Action:` body section dispatches correctly via Sub-Agent
+- Action not in `actions` array produces error with available actions list
+- Missing `## Action:` section for a listed action produces clear error
+
+## Non-Goals
+
+- Custom pipeline stages (the `pipeline` array stays fixed for propose-time artifact generation)
+- Requirement links for custom actions (instruction text is self-contained)
+- Hook/lifecycle patterns around existing actions
+- The QA Review skill itself (consumer-side implementation)
+
+## Decisions
+
+| Decision | Rationale | Alternatives |
+|----------|-----------|--------------|
+| Generic fallback in Step 5 rather than refactoring all 4 actions | Minimizes change surface. propose has unique Pipeline Traversal logic that can't be generalized. apply/finalize/init have requirement links that custom actions don't need. | Refactor all actions into a single generic dispatch — rejected because propose is fundamentally different. |
+| Custom actions go through change context detection | Most custom actions operate on a change (QA review, deploy, lint). Actions that don't need change context can handle this in their instruction. | Skip change context for custom actions — rejected because it would limit usefulness. |
+| Validate against `actions` array, fall back to built-in list if WORKFLOW.md missing | Graceful degradation for projects without WORKFLOW.md (pre-init). | Hard-require WORKFLOW.md for all invocations — rejected because init needs to work without it. |
+
+## Risks & Trade-offs
+
+- **Custom action instruction quality depends on author**: The sub-agent receives only the instruction text, no curated spec requirements. If the instruction is vague, the sub-agent may underperform. → Mitigation: This is the consumer's responsibility, same as writing good apply/finalize instructions.
+- **Change context detection for all custom actions**: Some custom actions may not need a change context (e.g., a project-wide linting action). → Mitigation: The instruction can tell the sub-agent to ignore the change context, or the consumer can add the action to the init-like skip list in a future iteration.
+
+## Open Questions
+
+No open questions.
+
+## Assumptions
+
+No assumptions made.

--- a/openspec/changes/2026-04-10-custom-actions/design.md
+++ b/openspec/changes/2026-04-10-custom-actions/design.md
@@ -24,7 +24,7 @@ User: /opsx:workflow qa-review
   → Router Step 2: load WORKFLOW.md (already happens)
   → Router Step 3: change context detection (same as apply/finalize)
   → Router Step 4: read ## Action: qa-review → ### Instruction (no requirement links)
-  → Router Step 5: generic fallback → spawn sub-agent with instruction + change context
+  → Router Step 5: generic fallback → execute instruction directly (agent decides whether to use sub-agent)
 ```
 
 **No new files, no new concepts.** The generic fallback reuses the existing Sub-Agent Execution pattern used by apply/finalize/init.
@@ -48,6 +48,7 @@ User: /opsx:workflow qa-review
 | Decision | Rationale | Alternatives |
 |----------|-----------|--------------|
 | Generic fallback in Step 5 rather than refactoring all 4 actions | Minimizes change surface. propose has unique Pipeline Traversal logic that can't be generalized. apply/finalize/init have requirement links that custom actions don't need. | Refactor all actions into a single generic dispatch — rejected because propose is fundamentally different. |
+| Execute instruction directly instead of forcing sub-agent | Custom actions may invoke skills that spawn their own sub-agents — forcing a router-level sub-agent would cause unnecessary nesting. Leaving execution mode to the agent gives custom action authors full flexibility. | Always spawn sub-agent — rejected because it constrains custom action authors and can cause double-nesting. |
 | Custom actions go through change context detection | Most custom actions operate on a change (QA review, deploy, lint). Actions that don't need change context can handle this in their instruction. | Skip change context for custom actions — rejected because it would limit usefulness. |
 | Validate against `actions` array, fall back to built-in list if WORKFLOW.md missing | Graceful degradation for projects without WORKFLOW.md (pre-init). | Hard-require WORKFLOW.md for all invocations — rejected because init needs to work without it. |
 

--- a/openspec/changes/2026-04-10-custom-actions/preflight.md
+++ b/openspec/changes/2026-04-10-custom-actions/preflight.md
@@ -1,0 +1,45 @@
+# Pre-Flight Check: Custom Actions
+
+## A. Traceability Matrix
+
+- [x] Custom action validation (Inline Action Definitions requirement) → Scenario: Router executes custom action as sub-agent, Scenario: Actions are not pipeline steps → SKILL.md Step 1
+- [x] Custom action dispatch (Router Dispatch Pattern requirement) → Scenario: Router dispatches custom action via generic fallback, Scenario: Router rejects action not in actions array → SKILL.md Step 5
+- [x] Custom action extensibility (Router + Actions Layer requirement) → Scenario: Router dispatches to custom actions, Scenario: Adding a custom action does not require router changes → SKILL.md Step 5, WORKFLOW.md body sections
+- [x] Layer separation preserved (Layer Separation requirement) → Scenario: Adding a custom action does not require router changes → WORKFLOW.md only
+
+## B. Gap Analysis
+
+No gaps identified. The change is additive — all edge cases (missing instruction section, action not in array, WORKFLOW.md fallback) are covered in the updated specs.
+
+## C. Side-Effect Analysis
+
+| System | Risk | Assessment |
+|--------|------|------------|
+| Built-in actions (init, propose, apply, finalize) | Regression from Step 1 validation change | Low — built-in actions are always in the `actions` array. The fallback to hardcoded list when WORKFLOW.md is missing preserves init behavior. |
+| Pipeline traversal (propose) | Custom actions accidentally entering pipeline | None — actions and pipeline are explicitly separate concepts in specs and router. |
+| Change context detection (Step 3) | Custom actions going through detection unnecessarily | Acceptable — detection is lightweight, and most custom actions benefit from it. |
+| Consumer template (`src/templates/workflow.md`) | Template sync with project WORKFLOW.md | Low — only a comment is added to the consumer template. |
+
+## D. Constitution Check
+
+- [x] Constitution mentions "Router immutability: MUST NOT be modified for project-specific behavior." The change is generic (enables any consumer to define any action), not project-specific. No constitution update needed.
+- [x] Architecture Rules reference "4 actions: init, propose, apply, finalize." This line in the constitution should be updated to reflect "4 built-in actions + custom actions."
+
+## E. Duplication & Consistency
+
+- [x] The custom action dispatch is described in both `workflow-contract` and `three-layer-architecture` specs — no contradiction, each at the appropriate abstraction level.
+- [x] Edge cases in `workflow-contract` spec are consistent with the new scenarios.
+
+## F. Assumption Audit
+
+No ASSUMPTION markers found in the updated spec sections or design.md. The existing assumptions in the unchanged parts of the specs remain valid.
+
+## G. Review Marker Audit
+
+No REVIEW markers found in any artifacts.
+
+---
+
+**Verdict: PASS**
+
+One action item: Update CONSTITUTION.md Architecture Rules line referencing "4 actions" during implementation.

--- a/openspec/changes/2026-04-10-custom-actions/proposal.md
+++ b/openspec/changes/2026-04-10-custom-actions/proposal.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 branch: custom-actions
 worktree: .claude/worktrees/custom-actions
 capabilities:

--- a/openspec/changes/2026-04-10-custom-actions/proposal.md
+++ b/openspec/changes/2026-04-10-custom-actions/proposal.md
@@ -1,0 +1,59 @@
+---
+status: active
+branch: custom-actions
+worktree: .claude/worktrees/custom-actions
+capabilities:
+  new: []
+  modified: [workflow-contract, three-layer-architecture]
+  removed: []
+---
+## Why
+
+Consumer projects need to define their own workflow actions (e.g., QA review, deployment, linting) without modifying the OPSX plugin source. The router already reads the `actions` array from WORKFLOW.md but ignores it for validation and dispatch — it hardcodes 4 actions. Opening this to consumer-defined actions enables extensibility with minimal change.
+
+## What Changes
+
+- Router SKILL.md Step 1 validates actions against the `actions` array from WORKFLOW.md instead of a hardcoded list
+- Router SKILL.md Step 5 adds a generic Sub-Agent Execution fallback for any action not in [init, propose, apply, finalize]
+- Consumer WORKFLOW.md template gets a comment explaining custom action usage
+- Specs updated to reflect that the system supports built-in + custom actions
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `workflow-contract`: Inline Action Definitions and Router Dispatch Pattern requirements updated to support consumer-defined actions beyond the 4 built-in ones
+- `three-layer-architecture`: Router + Actions Layer requirement updated from "4 commands" to "4 built-in commands + custom actions"
+
+### Removed Capabilities
+
+(none)
+
+### Consolidation Check
+
+N/A — no new specs proposed. Both modifications extend existing requirements in their natural home specs.
+
+## Impact
+
+- **Router SKILL.md** (`src/skills/workflow/SKILL.md`): ~10 lines changed (Step 1 dynamic validation + Step 5 generic fallback)
+- **Consumer template** (`src/templates/workflow.md`): Comment added to frontmatter
+- **Specs**: `workflow-contract/spec.md` and `three-layer-architecture/spec.md` updated
+- **No breaking changes**: All 4 built-in actions retain their exact current behavior
+
+## Scope & Boundaries
+
+**In scope:**
+- Dynamic action validation from `actions` array
+- Generic Sub-Agent dispatch for custom actions
+- Spec updates for the two affected capabilities
+- Consumer template hint
+
+**Out of scope:**
+- Requirement links for custom actions (they use self-contained instructions)
+- Custom pipeline stages (the `pipeline` array stays fixed for propose)
+- Hook/lifecycle patterns (actions are the extension mechanism)
+- The QA Review skill itself (that's a consumer-side implementation)

--- a/openspec/changes/2026-04-10-custom-actions/research.md
+++ b/openspec/changes/2026-04-10-custom-actions/research.md
@@ -1,0 +1,53 @@
+# Research: Custom Actions
+
+## 1. Current State
+
+The router SKILL.md dispatches to 4 hardcoded actions: `init`, `propose`, `apply`, `finalize`. The dispatch logic in Step 5 has:
+- `propose` — unique Pipeline Traversal pattern (iterates templates, generates artifacts, commits per step)
+- `apply`, `finalize`, `init` — identical Sub-Agent Execution pattern (read artifacts, spawn sub-agent with instruction + requirements)
+
+The `actions` array in WORKFLOW.md frontmatter (`actions: [init, propose, apply, finalize]`) is read by the router in Step 2 but only used descriptively — Step 1 hardcodes the valid action list, and Step 5 hardcodes dispatch per action.
+
+Three specs explicitly constrain the system to 4 actions:
+- **workflow-contract/spec.md** — "Inline Action Definitions" requirement: "The system SHALL support these actions: init, propose, apply, finalize."
+- **workflow-contract/spec.md** — "Router Dispatch Pattern" requirement: "The router SHALL support 4 commands: init, propose, apply, finalize."
+- **three-layer-architecture/spec.md** — "Router + Actions Layer" requirement: "The 4 commands are: init, propose, apply, finalize."
+
+The `actions` frontmatter field is already documented in the workflow-contract spec (WORKFLOW.md Pipeline Orchestration requirement) as a structured config field, but its scope is limited to listing the 4 built-in actions.
+
+## 2. External Research
+
+N/A — this is an internal architecture extension. The design pattern (open action registry with fallback dispatch) is a standard plugin/hook pattern.
+
+## 3. Approaches
+
+| Approach | Pro | Contra |
+|----------|-----|--------|
+| A: Generic fallback in router for unknown actions | Minimal change (~5 lines router, spec edits). Reuses existing Sub-Agent pattern. Consumer defines actions purely via WORKFLOW.md. | Router SKILL.md must be edited (but change is generic, not project-specific). Custom actions lack requirement links from SKILL.md. |
+| B: Lifecycle hooks (pre/post-action) in WORKFLOW.md | No router Step 1/5 changes. Hooks wrap around existing actions. | Over-engineered for the use case. Adds a new concept (hooks) instead of reusing existing concept (actions). Consumer still can't define standalone actions. |
+| C: Consumer wrapper skills that call /opsx:workflow internally | Zero plugin changes. | Breaks single-entry-point pattern. Consumer reinvents orchestration. |
+
+**Selected: Approach A** — discussed and confirmed with user during planning.
+
+## 4. Risks & Constraints
+
+- **Router immutability rule**: CONSTITUTION.md states the router "MUST NOT be modified for project-specific behavior." The proposed change is generic (not project-specific) — it enables any consumer to define any action. This is analogous to the existing worktree/automation config handling.
+- **No requirement links for custom actions**: Built-in actions get curated spec requirement links (Step 4 in SKILL.md). Custom actions don't have these — their instruction text in WORKFLOW.md must be self-contained. This is acceptable because custom actions are consumer-defined and don't have plugin-level specs.
+- **Propose is special**: The `propose` action has unique Pipeline Traversal logic that cannot be generalized. Custom actions will always use the Sub-Agent Execution pattern (like apply/finalize/init).
+- **Change context detection**: Custom actions will go through the same change context detection as apply/finalize (Step 3). This is correct — most custom actions need to know which change they operate on.
+
+## 5. Coverage Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Scope | Clear | Open the `actions` array + generic dispatch fallback |
+| Behavior | Clear | Custom actions use Sub-Agent pattern with instruction from WORKFLOW.md |
+| Data Model | Clear | No new data model — reuses existing WORKFLOW.md frontmatter + body sections |
+| UX | Clear | `/opsx:workflow <custom-action>` — same pattern as built-in actions |
+| Integration | Clear | 3 specs need updates, router Step 1 + Step 5 need edits |
+| Edge Cases | Clear | Missing instruction section, empty actions array, WORKFLOW.md fallback |
+| Constraints | Clear | Router immutability satisfied (generic change, not project-specific) |
+| Terminology | Clear | "Custom action" = any action in the `actions` array not in [init, propose, apply, finalize] |
+| Non-Functional | Clear | No performance impact — one additional array lookup in Step 1 |
+
+All categories Clear — no open questions.

--- a/openspec/changes/2026-04-10-custom-actions/review.md
+++ b/openspec/changes/2026-04-10-custom-actions/review.md
@@ -1,0 +1,88 @@
+## Review: Custom Actions
+
+### Summary
+
+| Dimension | Status |
+|-----------|--------|
+| Tasks | 4/4 complete |
+| Requirements | 8/8 verified |
+| Scenarios | 10/10 covered |
+| Scope | Clean — 0 untraced files |
+
+### Task-Diff Mapping
+
+| Task | Diff Evidence |
+|------|--------------|
+| 1.1. CONSTITUTION.md Architecture Rules | `openspec/CONSTITUTION.md` line 15: "4 actions: init, propose, apply, finalize" changed to "4 built-in actions (init, propose, apply, finalize) + consumer-defined custom actions" |
+| 2.1. SKILL.md Step 1 dynamic validation | `src/skills/workflow/SKILL.md` Step 1: hardcoded action list replaced with `actions` array from WORKFLOW.md frontmatter + fallback to built-in actions |
+| 2.2. SKILL.md Step 5 custom action dispatch | `src/skills/workflow/SKILL.md` Step 5: new "Custom Action — Direct Execution" block added after `init` dispatch |
+| 2.3. Consumer template comment | `src/templates/workflow.md`: YAML comment added after `actions` line explaining custom action usage |
+
+### Requirement Verification
+
+| Requirement | Spec | Status |
+|-------------|------|--------|
+| Inline Action Definitions | workflow-contract | PASS — SKILL.md now validates against `actions` array and dispatches custom actions via generic fallback |
+| Router Dispatch Pattern | workflow-contract | PASS — Step 1 validates against `actions` array, Step 5 has generic fallback for custom actions, fallback to built-in list when WORKFLOW.md missing |
+| WORKFLOW.md Pipeline Orchestration | workflow-contract | PASS — `actions` array semantics preserved, no pipeline changes |
+| Router + Actions Layer | three-layer-architecture | PASS — CONSTITUTION.md updated to reflect "4 built-in actions + consumer-defined custom actions" |
+| Layer Separation | three-layer-architecture | PASS — custom actions are defined in WORKFLOW.md, no router modification needed to add them |
+| Constitution Layer | three-layer-architecture | PASS — Architecture Rules updated, no structural changes |
+| Schema Layer | three-layer-architecture | PASS — no changes to pipeline or Smart Templates |
+| Automation Configuration | workflow-contract | PASS — not affected by this change |
+
+### Scenario Coverage
+
+| Scenario | Status |
+|----------|--------|
+| Router executes custom action as sub-agent (workflow-contract) | PASS — Step 5 generic fallback reads `## Action: <name>` and executes directly |
+| Actions are not pipeline steps (workflow-contract) | PASS — pipeline array unchanged, actions and pipeline remain separate |
+| Router dispatches custom action via generic fallback (workflow-contract) | PASS — Step 5 validates action, reads instruction, executes directly |
+| Router rejects action not in actions array (workflow-contract) | PASS — Step 1 validates against `actions` array, lists available actions if unrecognized |
+| Router dispatches to custom actions (three-layer-architecture) | PASS — generic fallback block handles any non-built-in action |
+| Adding a custom action does not require router changes (three-layer-architecture) | PASS — consumer adds to `actions` array + `## Action:` section, no SKILL.md changes needed |
+| Custom action without body section (workflow-contract edge case) | PASS — Step 3 of generic fallback: "If the `## Action: <name>` section is missing: report the error and stop" |
+| Router detects change from branch (workflow-contract) | PASS — unchanged, not affected |
+| Router dispatches propose to pipeline traversal (workflow-contract) | PASS — unchanged, not affected |
+| Router dispatches apply to sub-agent (workflow-contract) | PASS — unchanged, not affected |
+
+### Design Adherence
+
+| Decision | Adherence |
+|----------|-----------|
+| Generic fallback in Step 5 rather than refactoring all 4 actions | PASS — fallback block added after `init`, does not modify existing dispatch blocks |
+| Execute instruction directly instead of forcing sub-agent | PASS — instruction says "the agent decides whether to handle inline or spawn a sub-agent" |
+| Custom actions go through change context detection | PASS — no skip added for custom actions in Step 3 |
+| Validate against `actions` array, fall back to built-in list if WORKFLOW.md missing | PASS — Step 1 reads array from WORKFLOW.md, falls back to built-in actions |
+
+### Scope Control
+
+All changed files trace to implementation tasks:
+- `openspec/CONSTITUTION.md` — Task 1.1
+- `src/skills/workflow/SKILL.md` — Tasks 2.1, 2.2
+- `src/templates/workflow.md` — Task 2.3
+- `openspec/changes/2026-04-10-custom-actions/tasks.md` — progress tracking
+
+No untraced files. Spec changes (`openspec/specs/workflow-contract/spec.md`, `openspec/specs/three-layer-architecture/spec.md`) were made during the propose phase, not during apply.
+
+### Preflight Cross-Check
+
+The preflight identified one action item: "Update CONSTITUTION.md Architecture Rules line referencing '4 actions' during implementation." This was addressed by Task 1.1. All side-effect assessments remain valid — no regressions detected.
+
+### Findings
+
+#### CRITICAL
+
+(none)
+
+#### WARNING
+
+(none)
+
+#### SUGGESTION
+
+(none)
+
+### Verdict
+
+**PASS**

--- a/openspec/changes/2026-04-10-custom-actions/tasks.md
+++ b/openspec/changes/2026-04-10-custom-actions/tasks.md
@@ -2,21 +2,21 @@
 
 ## 1. Foundation
 
-- [ ] 1.1. Update CONSTITUTION.md Architecture Rules line to reflect "4 built-in actions + consumer-defined custom actions" instead of "4 actions"
+- [x] 1.1. Update CONSTITUTION.md Architecture Rules line to reflect "4 built-in actions + consumer-defined custom actions" instead of "4 actions"
 
 ## 2. Implementation
 
-- [ ] 2.1. Update `src/skills/workflow/SKILL.md` Step 1 — replace hardcoded action list with dynamic validation against `actions` array from WORKFLOW.md frontmatter, with fallback to built-in actions if WORKFLOW.md is missing
-- [ ] 2.2. Update `src/skills/workflow/SKILL.md` Step 5 — add generic fallback block for custom actions: read `## Action: <name>` instruction from WORKFLOW.md, execute directly with change context
-- [ ] 2.3. Update `src/templates/workflow.md` — add comment in frontmatter explaining custom action usage
+- [x] 2.1. Update `src/skills/workflow/SKILL.md` Step 1 — replace hardcoded action list with dynamic validation against `actions` array from WORKFLOW.md frontmatter, with fallback to built-in actions if WORKFLOW.md is missing
+- [x] 2.2. Update `src/skills/workflow/SKILL.md` Step 5 — add generic fallback block for custom actions: read `## Action: <name>` instruction from WORKFLOW.md, execute directly with change context
+- [x] 2.3. Update `src/templates/workflow.md` — add comment in frontmatter explaining custom action usage
 
 ## 3. QA Loop & Human Approval
 
-- [ ] 3.1. Metric Check: Built-in actions behave identically — PASS / FAIL
-- [ ] 3.2. Metric Check: Custom action in `actions` array dispatches correctly — PASS / FAIL
-- [ ] 3.3. Metric Check: Action not in array produces error with list — PASS / FAIL
-- [ ] 3.4. Metric Check: Missing `## Action:` section produces clear error — PASS / FAIL
-- [ ] 3.5. Auto-Verify: generate review.md using the review template.
+- [x] 3.1. Metric Check: Built-in actions behave identically — PASS
+- [x] 3.2. Metric Check: Custom action in `actions` array dispatches correctly — PASS
+- [x] 3.3. Metric Check: Action not in array produces error with list — PASS
+- [x] 3.4. Metric Check: Missing `## Action:` section produces clear error — PASS
+- [x] 3.5. Auto-Verify: generate review.md using the review template.
 - [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
 - [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
 - [ ] 3.8. Final Verify: regenerate review.md after all fixes. Skip if 3.7 was not entered.
@@ -24,10 +24,10 @@
 
 ## 4. Standard Tasks (Post-Implementation)
 
-- [ ] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
-- [ ] 4.2. Bump version
-- [ ] 4.3. Commit and push to remote
-- [ ] 4.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #33"`)
+- [x] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [x] 4.2. Bump version
+- [x] 4.3. Commit and push to remote
+- [x] 4.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #33"`)
 
 ## 5. Post-Merge Reminders
 

--- a/openspec/changes/2026-04-10-custom-actions/tasks.md
+++ b/openspec/changes/2026-04-10-custom-actions/tasks.md
@@ -1,0 +1,34 @@
+# Implementation Tasks: Custom Actions
+
+## 1. Foundation
+
+- [ ] 1.1. Update CONSTITUTION.md Architecture Rules line to reflect "4 built-in actions + consumer-defined custom actions" instead of "4 actions"
+
+## 2. Implementation
+
+- [ ] 2.1. Update `src/skills/workflow/SKILL.md` Step 1 — replace hardcoded action list with dynamic validation against `actions` array from WORKFLOW.md frontmatter, with fallback to built-in actions if WORKFLOW.md is missing
+- [ ] 2.2. Update `src/skills/workflow/SKILL.md` Step 5 — add generic fallback block for custom actions: read `## Action: <name>` instruction from WORKFLOW.md, execute directly with change context
+- [ ] 2.3. Update `src/templates/workflow.md` — add comment in frontmatter explaining custom action usage
+
+## 3. QA Loop & Human Approval
+
+- [ ] 3.1. Metric Check: Built-in actions behave identically — PASS / FAIL
+- [ ] 3.2. Metric Check: Custom action in `actions` array dispatches correctly — PASS / FAIL
+- [ ] 3.3. Metric Check: Action not in array produces error with list — PASS / FAIL
+- [ ] 3.4. Metric Check: Missing `## Action:` section produces clear error — PASS / FAIL
+- [ ] 3.5. Auto-Verify: generate review.md using the review template.
+- [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
+- [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
+- [ ] 3.8. Final Verify: regenerate review.md after all fixes. Skip if 3.7 was not entered.
+- [ ] 3.9. Approval: Only finish on explicit **"Approved"** by the user.
+
+## 4. Standard Tasks (Post-Implementation)
+
+- [ ] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [ ] 4.2. Bump version
+- [ ] 4.3. Commit and push to remote
+- [ ] 4.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #33"`)
+
+## 5. Post-Merge Reminders
+
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-10-custom-actions/tasks.md
+++ b/openspec/changes/2026-04-10-custom-actions/tasks.md
@@ -17,10 +17,10 @@
 - [x] 3.3. Metric Check: Action not in array produces error with list — PASS
 - [x] 3.4. Metric Check: Missing `## Action:` section produces clear error — PASS
 - [x] 3.5. Auto-Verify: generate review.md using the review template.
-- [ ] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
-- [ ] 3.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
-- [ ] 3.8. Final Verify: regenerate review.md after all fixes. Skip if 3.7 was not entered.
-- [ ] 3.9. Approval: Only finish on explicit **"Approved"** by the user.
+- [x] 3.6. User Testing: **Stop here!** Ask the user for manual approval.
+- [x] 3.7. Fix Loop: Not entered.
+- [x] 3.8. Final Verify: Skipped (3.7 not entered).
+- [x] 3.9. Approval: Approved by user.
 
 ## 4. Standard Tasks (Post-Implementation)
 

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -48,7 +48,7 @@ The system SHALL use `openspec/WORKFLOW.md` (YAML frontmatter) combined with Sma
 - **THEN** it SHALL require the `tasks` artifact to be complete before implementation begins
 
 ### Requirement: Router + Actions Layer
-The system SHALL deliver all commands through a single router SKILL.md that dispatches to inline actions defined in WORKFLOW.md. The router SHALL provide 4 built-in actions with specialized dispatch logic: `init` (project setup and health checks), `propose` (workspace creation and full artifact pipeline), `apply` (task implementation with review.md QA output), and `finalize` (changelog, docs, version bump, commit). The router SHALL additionally support consumer-defined custom actions listed in the WORKFLOW.md `actions` array, dispatching them via a generic Sub-Agent Execution pattern. The router SHALL be model-invocable (disable-model-invocation: false or absent).
+The system SHALL deliver all commands through a single router SKILL.md that dispatches to inline actions defined in WORKFLOW.md. The router SHALL provide 4 built-in actions with specialized dispatch logic: `init` (project setup and health checks), `propose` (workspace creation and full artifact pipeline), `apply` (task implementation with review.md QA output), and `finalize` (changelog, docs, version bump, commit). The router SHALL additionally support consumer-defined custom actions listed in the WORKFLOW.md `actions` array, reading their instruction from WORKFLOW.md and executing it directly (the agent decides whether to handle inline or spawn a sub-agent). The router SHALL be model-invocable (disable-model-invocation: false or absent).
 
 **User Story:** As a developer I want a single router that dispatches to built-in and custom actions, so that the command surface is extensible and all behavior is defined declaratively in WORKFLOW.md.
 
@@ -61,7 +61,7 @@ The system SHALL deliver all commands through a single router SKILL.md that disp
 - **GIVEN** a consumer WORKFLOW.md with `actions: [init, propose, apply, qa-review, finalize]`
 - **AND** a `## Action: qa-review` body section with `### Instruction`
 - **WHEN** a user invokes `/opsx:workflow qa-review`
-- **THEN** the router SHALL dispatch the custom action using the generic Sub-Agent Execution pattern
+- **THEN** the router SHALL read the instruction and execute it directly (agent decides execution mode)
 
 #### Scenario: Router is model-invocable
 - **GIVEN** the router `SKILL.md`

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -1,10 +1,9 @@
 ---
 order: 13
 category: reference
-status: accepted
+status: stable
 version: 3
 lastModified: 2026-04-10
-change: 2026-04-10-custom-actions
 ---
 ## Purpose
 

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -1,7 +1,7 @@
 ---
 order: 13
 category: reference
-status: draft
+status: accepted
 version: 3
 lastModified: 2026-04-10
 change: 2026-04-10-custom-actions

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -1,9 +1,10 @@
 ---
 order: 13
 category: reference
-status: stable
-version: 2
+status: draft
+version: 3
 lastModified: 2026-04-10
+change: 2026-04-10-custom-actions
 ---
 ## Purpose
 
@@ -46,15 +47,21 @@ The system SHALL use `openspec/WORKFLOW.md` (YAML frontmatter) combined with Sma
 - **WHEN** the apply configuration is inspected
 - **THEN** it SHALL require the `tasks` artifact to be complete before implementation begins
 
-### Requirement: Router + Actions Layer (4 commands: init, propose, apply, finalize)
-The system SHALL deliver all commands through a single router SKILL.md that dispatches to inline actions defined in WORKFLOW.md. The 4 commands are: `init` (project setup and health checks), `propose` (workspace creation and full artifact pipeline), `apply` (task implementation with review.md QA output), and `finalize` (changelog, docs, version bump, commit). The router SHALL be model-invocable (disable-model-invocation: false or absent).
+### Requirement: Router + Actions Layer
+The system SHALL deliver all commands through a single router SKILL.md that dispatches to inline actions defined in WORKFLOW.md. The router SHALL provide 4 built-in actions with specialized dispatch logic: `init` (project setup and health checks), `propose` (workspace creation and full artifact pipeline), `apply` (task implementation with review.md QA output), and `finalize` (changelog, docs, version bump, commit). The router SHALL additionally support consumer-defined custom actions listed in the WORKFLOW.md `actions` array, dispatching them via a generic Sub-Agent Execution pattern. The router SHALL be model-invocable (disable-model-invocation: false or absent).
 
-**User Story:** As a developer I want a single router that dispatches to 4 actions, so that the command surface is minimal and all behavior is defined declaratively in WORKFLOW.md.
+**User Story:** As a developer I want a single router that dispatches to built-in and custom actions, so that the command surface is extensible and all behavior is defined declaratively in WORKFLOW.md.
 
-#### Scenario: Router dispatches to actions
+#### Scenario: Router dispatches to built-in actions
 - **GIVEN** a fully installed plugin
 - **WHEN** the `skills/` directory is listed
 - **THEN** it SHALL contain a single router `SKILL.md` that dispatches to init, propose, apply, and finalize actions
+
+#### Scenario: Router dispatches to custom actions
+- **GIVEN** a consumer WORKFLOW.md with `actions: [init, propose, apply, qa-review, finalize]`
+- **AND** a `## Action: qa-review` body section with `### Instruction`
+- **WHEN** a user invokes `/opsx:workflow qa-review`
+- **THEN** the router SHALL dispatch the custom action using the generic Sub-Agent Execution pattern
 
 #### Scenario: Router is model-invocable
 - **GIVEN** the router `SKILL.md`
@@ -70,6 +77,11 @@ The three layers SHALL be independently modifiable. WORKFLOW.md and Smart Templa
 - **GIVEN** WORKFLOW.md is updated with a new action instruction
 - **WHEN** the change is applied
 - **THEN** existing actions SHALL continue to function without modification because they read WORKFLOW.md dynamically at runtime
+
+#### Scenario: Adding a custom action does not require router changes
+- **GIVEN** a consumer adds `qa-review` to their WORKFLOW.md `actions` array and writes a `## Action: qa-review` body section
+- **WHEN** the user invokes `/opsx:workflow qa-review`
+- **THEN** the router SHALL dispatch the custom action without any modification to the router SKILL.md
 
 #### Scenario: Constitution update does not require WORKFLOW.md changes
 - **GIVEN** a new code style rule is added to CONSTITUTION.md

--- a/openspec/specs/workflow-contract/spec.md
+++ b/openspec/specs/workflow-contract/spec.md
@@ -1,7 +1,7 @@
 ---
 order: 3
 category: reference
-status: draft
+status: accepted
 version: 3
 lastModified: 2026-04-10
 change: 2026-04-10-custom-actions

--- a/openspec/specs/workflow-contract/spec.md
+++ b/openspec/specs/workflow-contract/spec.md
@@ -81,7 +81,7 @@ All template files SHALL use the Smart Template format: markdown with YAML front
 
 WORKFLOW.md frontmatter SHALL contain `actions` as an array of action names. The array SHALL include the 4 built-in actions (`init`, `propose`, `apply`, `finalize`) and MAY include additional consumer-defined custom actions (e.g., `actions: [init, propose, apply, qa-review, finalize]`). Each action SHALL have a corresponding `## Action: <name>` section in the WORKFLOW.md markdown body containing only `### Instruction` (procedural guidance for the AI agent). For built-in actions, requirement links (clickable markdown links to specific spec requirements using the format `[Requirement Name](openspec/specs/<spec>/spec.md#requirement-<slug>)`) SHALL live in the SKILL.md file, NOT in WORKFLOW.md. Custom actions do not have requirement links in SKILL.md — their instruction text in WORKFLOW.md SHALL be self-contained. This structure ensures prose stays out of frontmatter, the sub-agent receives focused context, and requirement wiring is managed at the skill level for built-in actions. Actions are NOT pipeline steps — they do not generate artifacts in the pipeline sequence. Actions are invoked by the router when the user calls the corresponding command.
 
-For built-in actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and the requirement links from the SKILL.md, load the referenced requirement sections from specs, and spawn a sub-agent via the Agent tool with the instruction text as primary directive and the extracted requirements as behavioral context. For custom actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and spawn a sub-agent with the instruction text as primary directive and the change directory context — without spec requirement links.
+For built-in actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and the requirement links from the SKILL.md, load the referenced requirement sections from specs, and spawn a sub-agent via the Agent tool with the instruction text as primary directive and the extracted requirements as behavioral context. For custom actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and execute it directly — the executing agent decides whether to handle it inline or spawn a sub-agent based on the instruction content. Custom actions do not receive spec requirement links.
 
 The system SHALL provide 4 built-in actions: `init` (project initialization and health check), `propose` (pipeline traversal for artifact generation), `apply` (task implementation with review.md generation), and `finalize` (post-approval changelog, docs, and version-bump). Consumer projects MAY define additional custom actions by adding them to the `actions` array and providing corresponding `## Action: <name>` body sections.
 
@@ -107,7 +107,7 @@ The system SHALL provide 4 built-in actions: `init` (project initialization and 
 - **AND** a `## Action: qa-review` body section with `### Instruction`
 - **WHEN** a user invokes `/opsx:workflow qa-review`
 - **THEN** the router SHALL read the `### Instruction` from the `## Action: qa-review` body section
-- **AND** SHALL spawn a sub-agent with the instruction text as primary directive and the change directory context
+- **AND** SHALL execute the instruction directly (the agent decides whether to handle it inline or spawn a sub-agent)
 - **AND** SHALL NOT look for requirement links in the SKILL.md for this action
 
 #### Scenario: Actions are not pipeline steps
@@ -123,7 +123,7 @@ The system SHALL provide a single router skill that handles all user-facing comm
 1. **Intent recognition**: Determine which command was invoked and validate it against the `actions` array
 2. **Change context detection** (for all actions except `init`): Get current branch via `git rev-parse --abbrev-ref HEAD`, scan `openspec/changes/*/proposal.md` for a proposal whose `branch` frontmatter field matches, fall back to worktree convention if inside a worktree
 3. **WORKFLOW.md loading**: Read frontmatter for `templates_dir`, `pipeline`, and `actions`
-4. **Dispatch**: For `propose` — traverse the pipeline, generate artifacts, handle checkpoint/resume. For `apply`/`finalize`/`init` — read action definition from WORKFLOW.md, spawn sub-agent with instruction + requirement links. For custom actions — read action definition from WORKFLOW.md, spawn sub-agent with instruction + change context (no requirement links).
+4. **Dispatch**: For `propose` — traverse the pipeline, generate artifacts, handle checkpoint/resume. For `apply`/`finalize`/`init` — read action definition from WORKFLOW.md, spawn sub-agent with instruction + requirement links. For custom actions — read action definition from WORKFLOW.md, execute instruction directly with change context (no requirement links, agent decides execution mode).
 
 **User Story:** As a developer I want a single entry point that handles built-in and custom actions with shared logic, so that change detection and context loading happen once and consumer projects can extend the workflow.
 
@@ -157,7 +157,7 @@ The system SHALL provide a single router skill that handles all user-facing comm
 - **WHEN** a user invokes `/opsx:workflow qa-review`
 - **THEN** the router SHALL validate `qa-review` against the `actions` array
 - **AND** SHALL read the `### Instruction` from the `## Action: qa-review` section
-- **AND** SHALL spawn a sub-agent with the instruction and change context
+- **AND** SHALL execute the instruction directly (agent decides execution mode)
 - **AND** SHALL NOT look for requirement links in SKILL.md
 
 #### Scenario: Router rejects action not in actions array

--- a/openspec/specs/workflow-contract/spec.md
+++ b/openspec/specs/workflow-contract/spec.md
@@ -1,10 +1,9 @@
 ---
 order: 3
 category: reference
-status: accepted
+status: stable
 version: 3
 lastModified: 2026-04-10
-change: 2026-04-10-custom-actions
 ---
 ## Purpose
 

--- a/openspec/specs/workflow-contract/spec.md
+++ b/openspec/specs/workflow-contract/spec.md
@@ -1,9 +1,10 @@
 ---
 order: 3
 category: reference
-status: stable
-version: 2
+status: draft
+version: 3
 lastModified: 2026-04-10
+change: 2026-04-10-custom-actions
 ---
 ## Purpose
 
@@ -78,11 +79,13 @@ All template files SHALL use the Smart Template format: markdown with YAML front
 
 ### Requirement: Inline Action Definitions
 
-WORKFLOW.md frontmatter SHALL contain `actions` as a simple array of action names (e.g., `actions: [init, propose, apply, finalize]`). Each action SHALL have a corresponding `## Action: <name>` section in the WORKFLOW.md markdown body containing only `### Instruction` (procedural guidance for the AI agent). Requirement links (clickable markdown links to specific spec requirements using the format `[Requirement Name](openspec/specs/<spec>/spec.md#requirement-<slug>)`) SHALL live in the SKILL.md file for each action, NOT in WORKFLOW.md. This structure ensures prose stays out of frontmatter, the sub-agent receives focused context, and requirement wiring is managed at the skill level. Actions are NOT pipeline steps — they do not generate artifacts in the pipeline sequence. Actions are invoked by the router when the user calls the corresponding command. When executing an action, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and the requirement links from the SKILL.md, load the referenced requirement sections from specs, and spawn a sub-agent via the Agent tool with the instruction text as primary directive and the extracted requirements as behavioral context.
+WORKFLOW.md frontmatter SHALL contain `actions` as an array of action names. The array SHALL include the 4 built-in actions (`init`, `propose`, `apply`, `finalize`) and MAY include additional consumer-defined custom actions (e.g., `actions: [init, propose, apply, qa-review, finalize]`). Each action SHALL have a corresponding `## Action: <name>` section in the WORKFLOW.md markdown body containing only `### Instruction` (procedural guidance for the AI agent). For built-in actions, requirement links (clickable markdown links to specific spec requirements using the format `[Requirement Name](openspec/specs/<spec>/spec.md#requirement-<slug>)`) SHALL live in the SKILL.md file, NOT in WORKFLOW.md. Custom actions do not have requirement links in SKILL.md — their instruction text in WORKFLOW.md SHALL be self-contained. This structure ensures prose stays out of frontmatter, the sub-agent receives focused context, and requirement wiring is managed at the skill level for built-in actions. Actions are NOT pipeline steps — they do not generate artifacts in the pipeline sequence. Actions are invoked by the router when the user calls the corresponding command.
 
-The system SHALL support these actions: `init` (project initialization and health check), `propose` (pipeline traversal for artifact generation), `apply` (task implementation with review.md generation), and `finalize` (post-approval changelog, docs, and version-bump).
+For built-in actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and the requirement links from the SKILL.md, load the referenced requirement sections from specs, and spawn a sub-agent via the Agent tool with the instruction text as primary directive and the extracted requirements as behavioral context. For custom actions, the router SHALL read the `### Instruction` from the WORKFLOW.md body section and spawn a sub-agent with the instruction text as primary directive and the change directory context — without spec requirement links.
 
-**User Story:** As a plugin maintainer I want action definitions inline in WORKFLOW.md alongside the pipeline, so that all workflow orchestration lives in one file without separate action template files.
+The system SHALL provide 4 built-in actions: `init` (project initialization and health check), `propose` (pipeline traversal for artifact generation), `apply` (task implementation with review.md generation), and `finalize` (post-approval changelog, docs, and version-bump). Consumer projects MAY define additional custom actions by adding them to the `actions` array and providing corresponding `## Action: <name>` body sections.
+
+**User Story:** As a consumer project maintainer I want to define custom actions in my WORKFLOW.md alongside the built-in ones, so that I can extend the workflow with project-specific steps without modifying the plugin.
 
 #### Scenario: Action defined as body section with instruction
 - **GIVEN** a WORKFLOW.md with a `## Action: apply` body section
@@ -90,7 +93,7 @@ The system SHALL support these actions: `init` (project initialization and healt
 - **THEN** it SHALL contain `### Instruction` with procedural guidance text
 - **AND** it SHALL NOT contain requirement links (those live in the SKILL.md)
 
-#### Scenario: Router executes action as sub-agent
+#### Scenario: Router executes built-in action as sub-agent
 - **GIVEN** a user invokes `/opsx:workflow apply`
 - **WHEN** the router reads `## Action: apply` from WORKFLOW.md body and requirement links from the SKILL.md
 - **THEN** it SHALL parse the requirement links from the SKILL.md
@@ -99,22 +102,30 @@ The system SHALL support these actions: `init` (project initialization and healt
 - **AND** SHALL spawn a sub-agent with `### Instruction` text as primary directive and extracted requirements as behavioral context
 - **AND** the sub-agent SHALL NOT receive the router's full conversation history
 
+#### Scenario: Router executes custom action as sub-agent
+- **GIVEN** a WORKFLOW.md with `actions: [init, propose, apply, qa-review, finalize]`
+- **AND** a `## Action: qa-review` body section with `### Instruction`
+- **WHEN** a user invokes `/opsx:workflow qa-review`
+- **THEN** the router SHALL read the `### Instruction` from the `## Action: qa-review` body section
+- **AND** SHALL spawn a sub-agent with the instruction text as primary directive and the change directory context
+- **AND** SHALL NOT look for requirement links in the SKILL.md for this action
+
 #### Scenario: Actions are not pipeline steps
 - **GIVEN** a WORKFLOW.md with `pipeline: [research, proposal, specs, design, preflight, tasks, review]`
-- **AND** `actions: [init, propose, apply, finalize]`
+- **AND** `actions: [init, propose, apply, qa-review, finalize]`
 - **WHEN** the pipeline is traversed
 - **THEN** actions SHALL NOT be included in the pipeline artifact sequence
 - **AND** SHALL only be invoked via direct command or automation trigger
 
 ### Requirement: Router Dispatch Pattern
 
-The system SHALL provide a single router skill that handles all user-facing commands. The router SHALL support 4 commands: `init`, `propose`, `apply`, `finalize`. The router SHALL implement shared orchestration logic once:
-1. **Intent recognition**: Determine which command was invoked
-2. **Change context detection** (for propose, apply, finalize): Get current branch via `git rev-parse --abbrev-ref HEAD`, scan `openspec/changes/*/proposal.md` for a proposal whose `branch` frontmatter field matches, fall back to worktree convention if inside a worktree
+The system SHALL provide a single router skill that handles all user-facing commands. The router SHALL validate commands against the `actions` array from WORKFLOW.md frontmatter. If WORKFLOW.md is missing, the router SHALL fall back to the built-in actions: `init`, `propose`, `apply`, `finalize`. The router SHALL implement shared orchestration logic once:
+1. **Intent recognition**: Determine which command was invoked and validate it against the `actions` array
+2. **Change context detection** (for all actions except `init`): Get current branch via `git rev-parse --abbrev-ref HEAD`, scan `openspec/changes/*/proposal.md` for a proposal whose `branch` frontmatter field matches, fall back to worktree convention if inside a worktree
 3. **WORKFLOW.md loading**: Read frontmatter for `templates_dir`, `pipeline`, and `actions`
-4. **Dispatch**: For `propose` — traverse the pipeline, generate artifacts, handle checkpoint/resume. For `apply`/`finalize` — read action definition from WORKFLOW.md, spawn sub-agent. For `init` — no change context needed, execute init action directly.
+4. **Dispatch**: For `propose` — traverse the pipeline, generate artifacts, handle checkpoint/resume. For `apply`/`finalize`/`init` — read action definition from WORKFLOW.md, spawn sub-agent with instruction + requirement links. For custom actions — read action definition from WORKFLOW.md, spawn sub-agent with instruction + change context (no requirement links).
 
-**User Story:** As a developer I want a single entry point that handles all opsx commands with shared logic, so that change detection and context loading happen once instead of being copy-pasted across 11 skill files.
+**User Story:** As a developer I want a single entry point that handles built-in and custom actions with shared logic, so that change detection and context loading happen once and consumer projects can extend the workflow.
 
 #### Scenario: Router detects change from branch
 - **GIVEN** the user is on branch `my-feature`
@@ -140,6 +151,21 @@ The system SHALL provide a single router skill that handles all user-facing comm
 - **THEN** it SHALL skip change context detection
 - **AND** SHALL execute the init action directly
 
+#### Scenario: Router dispatches custom action via generic fallback
+- **GIVEN** a WORKFLOW.md with `actions: [init, propose, apply, qa-review, finalize]`
+- **AND** a `## Action: qa-review` body section with `### Instruction`
+- **WHEN** a user invokes `/opsx:workflow qa-review`
+- **THEN** the router SHALL validate `qa-review` against the `actions` array
+- **AND** SHALL read the `### Instruction` from the `## Action: qa-review` section
+- **AND** SHALL spawn a sub-agent with the instruction and change context
+- **AND** SHALL NOT look for requirement links in SKILL.md
+
+#### Scenario: Router rejects action not in actions array
+- **GIVEN** a WORKFLOW.md with `actions: [init, propose, apply, finalize]`
+- **WHEN** a user invokes `/opsx:workflow deploy`
+- **THEN** the router SHALL report that `deploy` is not a recognized action
+- **AND** SHALL list the available actions from the `actions` array
+
 ### Requirement: Automation Configuration
 
 WORKFLOW.md frontmatter SHALL support an optional `automation` section that configures CI-triggered pipeline behavior. The `automation` section SHALL contain: `post_approval` (object defining what happens when a PR receives all required review approvals). The `post_approval` object SHALL contain: `action` (name of the action to execute — e.g., `finalize`) and `labels` (object mapping state names to GitHub label names — `running`, `complete`, `failed`).
@@ -164,8 +190,10 @@ WORKFLOW.md frontmatter SHALL support an optional `automation` section that conf
 - **WORKFLOW.md with malformed YAML**: Router SHALL report a parse error and stop.
 - **Empty `pipeline` array**: Router SHALL report that no artifacts are defined and stop.
 - **`templates_dir` points to nonexistent directory**: Router SHALL report the missing directory and suggest running `/opsx:workflow init`.
-- **Unknown action referenced**: If an action name does not match a defined action in `actions:`, the router SHALL report the error and list available actions.
+- **Unknown action referenced**: If an action name does not match any entry in the `actions` array from WORKFLOW.md frontmatter, the router SHALL report the error and list available actions.
 - **Action with missing spec**: If a spec listed in the SKILL.md's requirement links does not exist at the referenced path, the sub-agent SHALL proceed without it and note the missing spec.
+- **Custom action without body section**: If a custom action is listed in the `actions` array but has no corresponding `## Action: <name>` body section in WORKFLOW.md, the router SHALL report the missing instruction and stop.
+- **Custom action with init skip**: Custom actions SHALL go through change context detection (like apply/finalize), not skip it like init. If a custom action does not need change context, the instruction text should handle that.
 
 ## Assumptions
 

--- a/src/.claude-plugin/plugin.json
+++ b/src/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx",
   "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "fritze.dev"
   },

--- a/src/skills/workflow/SKILL.md
+++ b/src/skills/workflow/SKILL.md
@@ -12,9 +12,9 @@ Central orchestration for the OpenSpec workflow. The first argument determines t
 
 ## Step 1: Identify Action
 
-Parse the first argument to determine which action to run. Valid actions: `init`, `propose`, `apply`, `finalize`.
+Parse the first argument to determine which action to run. Read the `actions` array from WORKFLOW.md frontmatter to determine valid actions. If WORKFLOW.md is missing, fall back to built-in actions: `init`, `propose`, `apply`, `finalize`.
 
-If no action provided or unrecognized: list available actions and ask the user to choose.
+If no action provided or unrecognized: list available actions from the array and ask the user to choose.
 
 ## Step 2: Load WORKFLOW.md
 
@@ -124,6 +124,15 @@ For `propose`, `apply`, `finalize`:
 
 1. If WORKFLOW.md missing: this IS the fresh install — proceed with default init behavior
 2. Spawn sub-agent with instruction + extracted requirements
+
+### Custom Action — Direct Execution
+
+For any action not listed above (propose, apply, finalize, init):
+1. Read all change artifacts for context (all files in change directory)
+2. Read the `## Action: <name>` instruction from WORKFLOW.md
+3. If the `## Action: <name>` section is missing: report the error and stop
+4. Execute the instruction directly with change directory context — the agent decides whether to handle inline or spawn a sub-agent based on the instruction content
+5. No spec requirements are loaded (custom actions are self-contained via their instruction)
 
 ## Guardrails
 

--- a/src/templates/workflow.md
+++ b/src/templates/workflow.md
@@ -4,6 +4,8 @@ templates_dir: openspec/templates
 pipeline: [research, proposal, specs, design, preflight, tasks, review]
 
 actions: [init, propose, apply, finalize]
+# Add custom actions here (e.g. qa-review) and define matching
+# ## Action: <name> sections in the body below.
 
 # worktree:
 #   enabled: false


### PR DESCRIPTION
## Summary

- Router SKILL.md now validates actions against the `actions` array from WORKFLOW.md frontmatter instead of a hardcoded list
- New generic fallback dispatch in Step 5 for consumer-defined custom actions — executes the instruction directly (agent decides execution mode)
- Consumer WORKFLOW.md template includes a comment explaining how to add custom actions
- Specs (workflow-contract, three-layer-architecture) updated to reflect built-in + custom actions

## How consumers use it

1. Add custom action to `actions` array in their `openspec/WORKFLOW.md`:
   ```yaml
   actions: [init, propose, apply, qa-review, finalize]
   ```
2. Write a `## Action: qa-review` section with `### Instruction` in WORKFLOW.md body
3. Run `/opsx:workflow qa-review`

No plugin changes needed — just WORKFLOW.md configuration.

## Test plan

- [x] Built-in actions (init, propose, apply, finalize) behave identically
- [x] Custom action dispatches correctly via generic fallback
- [x] Action not in array produces error with available actions list
- [x] Missing `## Action:` section produces clear error

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)