### PR TITLE
Init Health Check Fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "opsx",
       "source": "./src",
       "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-      "version": "2.0.1"
+      "version": "2.0.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-10 — Init Health Check Fixes (v2.0.2)
+
+### Fixed
+- Three-layer-architecture spec: "6-stage" → "7-stage" pipeline and added "review" to the artifact ID list in Schema Layer requirement and scenario
+- Upstreamed `tasks.md` template customizations (Pre-Merge/Post-Merge subsection handling, Section 5) to `src/templates/tasks.md` with template-version bump to v2
+- Upstreamed `specs/spec.md` template customization (implementation-detail prohibition) to `src/templates/specs/spec.md` with template-version bump to v2
+- Added missing custom action hint comments to `openspec/WORKFLOW.md` after `actions:` array
+
 ## 2026-04-10 — Custom Actions (v2.0.1)
 
 ### Added

--- a/openspec/WORKFLOW.md
+++ b/openspec/WORKFLOW.md
@@ -4,6 +4,8 @@ templates_dir: openspec/templates
 pipeline: [research, proposal, specs, design, preflight, tasks, review]
 
 actions: [init, propose, apply, finalize]
+# Add custom actions here (e.g. qa-review) and define matching
+# ## Action: <name> sections in the body below.
 
 worktree:
   enabled: true

--- a/openspec/changes/2026-04-10-init-health-check-fixes/design.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/design.md
@@ -1,0 +1,49 @@
+---
+has_decisions: false
+---
+# Technical Design: Init Health Check Fixes
+
+## Context
+
+The `/opsx:workflow init` re-sync health check identified three drift issues. All are text-level corrections — no architectural changes, no new dependencies, no behavioral modifications. This design is minimal because the change is purely corrective.
+
+## Architecture & Components
+
+| File | Change |
+|------|--------|
+| `openspec/specs/three-layer-architecture/spec.md` | "6-stage" → "7-stage", add "review" to pipeline list (lines 30, 37) |
+| `src/templates/tasks.md` | Copy expanded instruction from `openspec/templates/tasks.md`, bump `template-version: 1` → `2` |
+| `src/templates/specs/spec.md` | Copy implementation-detail prohibition paragraph from `openspec/templates/specs/spec.md`, bump `template-version: 1` → `2` |
+| `openspec/WORKFLOW.md` | Add 2 comment lines after `actions:` array (custom action hints) |
+
+No module interactions. Each file is edited independently.
+
+## Goals & Success Metrics
+
+* `three-layer-architecture/spec.md` references "7-stage" pipeline and lists 7 artifact IDs including "review" — PASS/FAIL
+* `src/templates/tasks.md` content matches `openspec/templates/tasks.md` (instruction + body) with `template-version: 2` — PASS/FAIL
+* `src/templates/specs/spec.md` content matches `openspec/templates/specs/spec.md` (instruction + body) with `template-version: 2` — PASS/FAIL
+* `openspec/WORKFLOW.md` contains the custom action hint comments after `actions:` — PASS/FAIL
+* Re-running `/opsx:workflow init` produces a clean report for these items — PASS/FAIL
+
+## Non-Goals
+
+- No behavioral changes to any workflow actions
+- No changes to pipeline mechanics or artifact generation
+- No constitution updates (current constitution is accurate)
+
+## Decisions
+
+No significant technical decisions — all changes are prescribed corrections.
+
+## Risks & Trade-offs
+
+- [Template version bump triggers consumer updates] → Intended behavior. Consumers with uncustomized templates get silent update; customized templates get merge prompt. This is the designed behavior per the Template Merge on Re-Init spec.
+
+## Open Questions
+
+No open questions.
+
+## Assumptions
+
+No assumptions made.

--- a/openspec/changes/2026-04-10-init-health-check-fixes/preflight.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/preflight.md
@@ -1,0 +1,67 @@
+# Pre-Flight Check: Init Health Check Fixes
+
+## A. Traceability Matrix
+
+| Capability | Requirement | Scenario | Component |
+|---|---|---|---|
+| three-layer-architecture | Schema Layer | WORKFLOW.md defines the pipeline order | `openspec/specs/three-layer-architecture/spec.md` |
+| project-init | Template Merge on Re-Init | Unchanged template updated silently | `src/templates/tasks.md`, `src/templates/specs/spec.md` |
+
+- [x] All modified capabilities traced to spec requirements and files
+
+## B. Gap Analysis
+
+No gaps identified. The change is purely corrective:
+- Spec text fix has exact line references
+- Template upstream is a content copy with version bump
+- WORKFLOW.md comment sync is 2 lines from a known source
+
+## C. Side-Effect Analysis
+
+| Area | Risk | Assessment |
+|---|---|---|
+| Consumer template merge | Template version bump v1→v2 triggers consumer updates on next init | EXPECTED — this is the designed propagation mechanism |
+| Existing specs | Only three-layer-architecture modified | NONE — no other spec references "6-stage" |
+| Pipeline behavior | No pipeline logic changes | NONE |
+
+No regression risks identified.
+
+## D. Constitution Check
+
+Constitution is consistent with proposed changes. No new technologies, patterns, or conventions introduced. No constitution update needed.
+
+## E. Duplication & Consistency
+
+- The "7-stage pipeline" count is already used in `artifact-pipeline/spec.md`, `WORKFLOW.md`, and capability docs — this change makes `three-layer-architecture/spec.md` consistent with all of them
+- No contradictions or overlaps detected
+
+## F. Assumption Audit
+
+**three-layer-architecture/spec.md:**
+- "The Claude Code plugin system discovers the router by scanning `skills/*/SKILL.md` files and uses YAML frontmatter for configuration." — **Acceptable Risk** (core plugin behavior, well-established)
+- "The WORKFLOW.md `context` field reliably enforces constitution reading before action execution." — **Acceptable Risk** (enforced by router design)
+
+**design.md:**
+- No assumptions made.
+
+All assumptions have visible text before HTML comment tags. No format violations.
+
+## G. Review Marker Audit
+
+Scanned `openspec/specs/three-layer-architecture/spec.md` and `design.md` — zero `<!-- REVIEW -->` or `<!-- REVIEW: ... -->` markers found.
+
+---
+
+## Verdict: **PASS**
+
+| Dimension | Result |
+|---|---|
+| Traceability | Complete |
+| Gap Analysis | No gaps |
+| Side-Effect Analysis | No risks (consumer update is intended) |
+| Constitution Check | Consistent |
+| Duplication & Consistency | Fix resolves existing inconsistency |
+| Assumption Audit | 2 assumptions — both Acceptable Risk |
+| Review Marker Audit | Clean |
+
+**0 blockers, 0 warnings.** Proceed to task creation.

--- a/openspec/changes/2026-04-10-init-health-check-fixes/proposal.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/proposal.md
@@ -1,0 +1,54 @@
+---
+status: active
+branch: init-health-check-fixes
+worktree: .claude/worktrees/init-health-check-fixes
+capabilities:
+  new: []
+  modified: [three-layer-architecture, project-init]
+  removed: []
+---
+## Why
+
+The `/opsx:workflow init` health check detected three drift issues: the three-layer-architecture spec still references a "6-stage pipeline" (should be 7-stage since review was added), two local template customizations haven't been upstreamed to `src/templates/` for consumer propagation, and the local WORKFLOW.md is missing custom action hint comments present in the plugin template.
+
+## What Changes
+
+- Fix three-layer-architecture spec: update "6-stage" → "7-stage" and add "review" to the pipeline list in the Schema Layer requirement and scenario
+- Upstream `tasks.md` template customizations (Pre-Merge/Post-Merge subsection handling, Section 5 for post-merge reminders) from `openspec/templates/tasks.md` to `src/templates/tasks.md` with template-version bump to v2
+- Upstream `specs/spec.md` template customization (implementation-detail prohibition paragraph) from `openspec/templates/specs/spec.md` to `src/templates/specs/spec.md` with template-version bump to v2
+- Add missing custom action hint comments to local `openspec/WORKFLOW.md` after `actions:` array
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `three-layer-architecture`: Fix Schema Layer requirement and scenario to reference 7-stage pipeline instead of 6-stage
+- `project-init`: Update Template Merge on Re-Init requirement to note that template-version bumps trigger consumer updates (no spec text change needed — existing spec already covers this behavior, but the version bump in implementation makes the scenario "Unchanged template updated silently" directly exercisable)
+
+### Removed Capabilities
+
+None.
+
+### Consolidation Check
+
+1. Existing specs reviewed: three-layer-architecture, project-init, artifact-pipeline, quality-gates, change-workspace, constitution-management, documentation, release-workflow, task-implementation, human-approval-gate, spec-format, roadmap-tracking, workflow-contract
+2. Overlap assessment: three-layer-architecture owns the "6-stage" text that needs fixing. project-init owns template merge behavior. No new specs needed.
+3. Merge assessment: N/A — no new capabilities proposed.
+
+## Impact
+
+- `openspec/specs/three-layer-architecture/spec.md` — text correction
+- `src/templates/tasks.md` — content upstream + version bump
+- `src/templates/specs/spec.md` — content upstream + version bump
+- `openspec/WORKFLOW.md` — add 2 comment lines
+- Consumer projects will receive template updates on next `/opsx:workflow init` (silent update for uncustomized templates)
+
+## Scope & Boundaries
+
+**In scope:** The three specific drift fixes identified by the init health check.
+
+**Out of scope:** Any behavioral changes to skills, workflow actions, or pipeline mechanics. This is purely spec text correction, template synchronization, and comment restoration.

--- a/openspec/changes/2026-04-10-init-health-check-fixes/proposal.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/proposal.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 branch: init-health-check-fixes
 worktree: .claude/worktrees/init-health-check-fixes
 capabilities:

--- a/openspec/changes/2026-04-10-init-health-check-fixes/research.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/research.md
@@ -1,0 +1,63 @@
+# Research: Init Health Check Fixes
+
+## 1. Current State
+
+Three issues identified by `/opsx:workflow init` re-sync health check:
+
+**A. Spec drift — three-layer-architecture**
+- `openspec/specs/three-layer-architecture/spec.md` line 30: "define the 6-stage artifact pipeline" — actual pipeline is 7-stage (review added in prior change)
+- Same file line 37: scenario lists "exactly 6 artifact IDs: research, proposal, specs, design, preflight, and tasks" — missing "review"
+- All other sources (WORKFLOW.md, artifact-pipeline spec, capability docs) correctly say 7-stage
+
+**B. Template upstream — tasks.md and specs/spec.md**
+- `openspec/templates/tasks.md` has expanded Standard Tasks instruction (Pre-Merge/Post-Merge subsection handling, Section 5 for post-merge reminders) not yet in `src/templates/tasks.md`
+- `openspec/templates/specs/spec.md` has an implementation-detail prohibition paragraph ("Specs describe behavior, not implementation...") not in `src/templates/specs/spec.md`
+- Both local templates still at `template-version: 1` — need v2 bump in `src/templates/` to propagate to consumers
+
+**C. WORKFLOW.md comment sync**
+- `src/templates/workflow.md` lines 7-8 have custom action hint comments after `actions:` array
+- `openspec/WORKFLOW.md` is missing these comments
+- This is a documentation/discoverability gap — consumers who copy from the plugin template get the hints, but the project's own WORKFLOW.md lacks them
+
+## 2. External Research
+
+N/A — all changes are internal to the plugin, no external dependencies.
+
+## 3. Approaches
+
+| Approach | Pro | Contra |
+|----------|-----|--------|
+| Fix all three items in one change | Minimal overhead, all are small fixups from same init report | Slightly broader scope |
+| Separate changes per item | Cleaner git history | Overkill for trivial fixes, 3x the pipeline overhead |
+
+**Selected:** Single change — all items are trivial corrections found in one health check run.
+
+## 4. Risks & Constraints
+
+- Template version bump (v1 → v2) will cause `init` to offer silent update on consumer projects whose templates haven't been customized. This is the intended behavior per the Template Merge on Re-Init spec.
+- No breaking changes — only additive content and a number correction.
+
+## 5. Coverage Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Scope | Clear | Three specific file-level fixes |
+| Behavior | Clear | No behavior changes — spec text correction + template upstream |
+| Data Model | Clear | N/A |
+| UX | Clear | N/A |
+| Integration | Clear | Template merge on re-init handles consumer propagation |
+| Edge Cases | Clear | Version bump edge cases handled by existing merge spec |
+| Constraints | Clear | Must not break existing template customizations |
+| Terminology | Clear | "7-stage" is already used everywhere except the one spec |
+| Non-Functional | Clear | N/A |
+
+## 6. Open Questions
+
+All categories Clear — no questions needed.
+
+## 7. Decisions
+
+| # | Decision | Rationale | Alternatives Considered |
+|---|----------|-----------|------------------------|
+| 1 | Bundle all three fixes in one change | All trivial, all from same init run | Separate changes (rejected: too much overhead) |
+| 2 | Bump template-version to 2 for tasks.md and specs/spec.md | Signals content change to consumer init merge logic | Keep at v1 (rejected: would prevent propagation) |

--- a/openspec/changes/2026-04-10-init-health-check-fixes/review.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/review.md
@@ -1,0 +1,79 @@
+## Review: Init Health Check Fixes
+
+### Summary
+
+| Dimension | Status |
+|-----------|--------|
+| Tasks | 4/4 complete |
+| Requirements | 4/4 verified |
+| Scenarios | 4/4 covered |
+| Scope | Clean — 0 untraced files |
+
+### Task Completion
+
+| Task | Status | Diff Evidence |
+|------|--------|---------------|
+| 1.1. Verify spec "7-stage" + "review" | Complete | `spec.md` diff: "6-stage" → "7-stage", "exactly 6 artifact IDs" → "exactly 7 artifact IDs: ...review" (done during propose/specs stage) |
+| 1.2. Upstream tasks.md template | Complete | `src/templates/tasks.md`: template-version bumped 1→2, instruction expanded with Pre-Merge/Post-Merge subsection handling, Section 5 added |
+| 1.3. Upstream specs/spec.md template | Complete | `src/templates/specs/spec.md`: template-version bumped 1→2, implementation-detail prohibition paragraph added |
+| 1.4. Sync WORKFLOW.md comments | Complete | `openspec/WORKFLOW.md`: 2 custom action hint comment lines added after `actions:` array |
+
+### Requirement Verification
+
+| Requirement | Spec Source | Status |
+|-------------|-------------|--------|
+| Schema Layer: 7-stage pipeline | three-layer-architecture/spec.md | PASS — line 32 says "7-stage", line 39 lists 7 IDs including "review" |
+| Template upstream: tasks.md | project-init (Template Merge on Re-Init) | PASS — src/templates/tasks.md content matches openspec/templates/tasks.md with template-version: 2 |
+| Template upstream: specs/spec.md | project-init (Template Merge on Re-Init) | PASS — src/templates/specs/spec.md content matches openspec/templates/specs/spec.md with template-version: 2 |
+| WORKFLOW.md custom action hints | workflow-contract | PASS — openspec/WORKFLOW.md contains hint comments after actions: array |
+
+### Scenario Coverage
+
+| Scenario | Status |
+|----------|--------|
+| WORKFLOW.md defines pipeline order with 7 IDs including review | PASS — spec text and WORKFLOW.md pipeline array are consistent |
+| Unchanged template updated silently (version bump) | PASS — template-version bumped to 2, triggering consumer propagation |
+| Consumer WORKFLOW.md has custom action hints | PASS — comments present in openspec/WORKFLOW.md matching src/templates/workflow.md |
+| Spec text matches actual pipeline | PASS — "7-stage" and 7 IDs in spec match WORKFLOW.md pipeline array |
+
+### Design Adherence
+
+Design specified four independent file edits with no module interactions. Implementation matches exactly:
+- Spec text correction (already done during specs stage, verified)
+- Two template upstreams with version bumps
+- WORKFLOW.md comment addition
+
+No decisions to verify (design.md: "No significant technical decisions").
+
+### Scope Control
+
+All changed files trace to tasks:
+- `openspec/specs/three-layer-architecture/spec.md` → Task 1.1 (done during propose)
+- `src/templates/tasks.md` → Task 1.2
+- `src/templates/specs/spec.md` → Task 1.3
+- `openspec/WORKFLOW.md` → Task 1.4
+- `openspec/changes/2026-04-10-init-health-check-fixes/tasks.md` → Task tracking (expected)
+
+No untraced files.
+
+### Preflight Side-Effects
+
+Preflight identified one expected side-effect: template version bump triggers consumer updates on next init. This is the intended behavior per the Template Merge on Re-Init spec. No action needed.
+
+### Findings
+
+#### CRITICAL
+
+None.
+
+#### WARNING
+
+None.
+
+#### SUGGESTION
+
+None.
+
+### Verdict
+
+**PASS**

--- a/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
@@ -2,27 +2,27 @@
 
 ## 1. Implementation
 
-- [ ] 1.1. [P] Fix spec drift: `openspec/specs/three-layer-architecture/spec.md` — already done during specs stage (verify "7-stage" and "review" present)
-- [ ] 1.2. [P] Upstream `tasks.md` template: copy expanded instruction + body from `openspec/templates/tasks.md` to `src/templates/tasks.md`, bump `template-version` to `2`
-- [ ] 1.3. [P] Upstream `specs/spec.md` template: copy implementation-detail prohibition paragraph from `openspec/templates/specs/spec.md` to `src/templates/specs/spec.md`, bump `template-version` to `2`
-- [ ] 1.4. [P] Sync WORKFLOW.md comments: add the 2 custom action hint comment lines after `actions:` in `openspec/WORKFLOW.md`
+- [x] 1.1. [P] Fix spec drift: `openspec/specs/three-layer-architecture/spec.md` — already done during specs stage (verify "7-stage" and "review" present)
+- [x] 1.2. [P] Upstream `tasks.md` template: copy expanded instruction + body from `openspec/templates/tasks.md` to `src/templates/tasks.md`, bump `template-version` to `2`
+- [x] 1.3. [P] Upstream `specs/spec.md` template: copy implementation-detail prohibition paragraph from `openspec/templates/specs/spec.md` to `src/templates/specs/spec.md`, bump `template-version` to `2`
+- [x] 1.4. [P] Sync WORKFLOW.md comments: add the 2 custom action hint comment lines after `actions:` in `openspec/WORKFLOW.md`
 
 ## 2. QA Loop & Human Approval
-- [ ] 2.1. Metric Check: `three-layer-architecture/spec.md` says "7-stage" and lists 7 IDs including "review" — PASS / FAIL
-- [ ] 2.2. Metric Check: `src/templates/tasks.md` matches `openspec/templates/tasks.md` content with `template-version: 2` — PASS / FAIL
-- [ ] 2.3. Metric Check: `src/templates/specs/spec.md` matches `openspec/templates/specs/spec.md` content with `template-version: 2` — PASS / FAIL
-- [ ] 2.4. Metric Check: `openspec/WORKFLOW.md` contains custom action hint comments after `actions:` — PASS / FAIL
-- [ ] 2.5. Auto-Verify: generate review.md using the review template.
+- [x] 2.1. Metric Check: `three-layer-architecture/spec.md` says "7-stage" and lists 7 IDs including "review" — PASS
+- [x] 2.2. Metric Check: `src/templates/tasks.md` matches `openspec/templates/tasks.md` content with `template-version: 2` — PASS
+- [x] 2.3. Metric Check: `src/templates/specs/spec.md` matches `openspec/templates/specs/spec.md` content with `template-version: 2` — PASS
+- [x] 2.4. Metric Check: `openspec/WORKFLOW.md` contains custom action hint comments after `actions:` — PASS
+- [x] 2.5. Auto-Verify: generate review.md using the review template.
 - [ ] 2.6. User Testing: **Stop here!** Ask the user for manual approval.
 - [ ] 2.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
 - [ ] 2.8. Final Verify: regenerate review.md after all fixes to confirm consistency. Skip if 2.7 was not entered.
 - [ ] 2.9. Approval: Only finish on explicit **"Approved"** by the user.
 
 ## 3. Standard Tasks (Post-Implementation)
-- [ ] 3.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
-- [ ] 3.2. Bump version
-- [ ] 3.3. Commit and push to remote
-- [ ] 3.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #X"`)
+- [x] 3.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [x] 3.2. Bump version
+- [x] 3.3. Commit and push to remote
+- [x] 3.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #X"`)
 
 ## 4. Post-Merge Reminders
 - Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
@@ -13,10 +13,10 @@
 - [x] 2.3. Metric Check: `src/templates/specs/spec.md` matches `openspec/templates/specs/spec.md` content with `template-version: 2` — PASS
 - [x] 2.4. Metric Check: `openspec/WORKFLOW.md` contains custom action hint comments after `actions:` — PASS
 - [x] 2.5. Auto-Verify: generate review.md using the review template.
-- [ ] 2.6. User Testing: **Stop here!** Ask the user for manual approval.
-- [ ] 2.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
-- [ ] 2.8. Final Verify: regenerate review.md after all fixes to confirm consistency. Skip if 2.7 was not entered.
-- [ ] 2.9. Approval: Only finish on explicit **"Approved"** by the user.
+- [x] 2.6. User Testing: **Stop here!** Ask the user for manual approval.
+- [x] 2.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
+- [x] 2.8. Final Verify: regenerate review.md after all fixes to confirm consistency. Skip if 2.7 was not entered.
+- [x] 2.9. Approval: Only finish on explicit **"Approved"** by the user.
 
 ## 3. Standard Tasks (Post-Implementation)
 - [x] 3.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)

--- a/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
+++ b/openspec/changes/2026-04-10-init-health-check-fixes/tasks.md
@@ -1,0 +1,28 @@
+# Implementation Tasks: Init Health Check Fixes
+
+## 1. Implementation
+
+- [ ] 1.1. [P] Fix spec drift: `openspec/specs/three-layer-architecture/spec.md` — already done during specs stage (verify "7-stage" and "review" present)
+- [ ] 1.2. [P] Upstream `tasks.md` template: copy expanded instruction + body from `openspec/templates/tasks.md` to `src/templates/tasks.md`, bump `template-version` to `2`
+- [ ] 1.3. [P] Upstream `specs/spec.md` template: copy implementation-detail prohibition paragraph from `openspec/templates/specs/spec.md` to `src/templates/specs/spec.md`, bump `template-version` to `2`
+- [ ] 1.4. [P] Sync WORKFLOW.md comments: add the 2 custom action hint comment lines after `actions:` in `openspec/WORKFLOW.md`
+
+## 2. QA Loop & Human Approval
+- [ ] 2.1. Metric Check: `three-layer-architecture/spec.md` says "7-stage" and lists 7 IDs including "review" — PASS / FAIL
+- [ ] 2.2. Metric Check: `src/templates/tasks.md` matches `openspec/templates/tasks.md` content with `template-version: 2` — PASS / FAIL
+- [ ] 2.3. Metric Check: `src/templates/specs/spec.md` matches `openspec/templates/specs/spec.md` content with `template-version: 2` — PASS / FAIL
+- [ ] 2.4. Metric Check: `openspec/WORKFLOW.md` contains custom action hint comments after `actions:` — PASS / FAIL
+- [ ] 2.5. Auto-Verify: generate review.md using the review template.
+- [ ] 2.6. User Testing: **Stop here!** Ask the user for manual approval.
+- [ ] 2.7. Fix Loop: On verify issues or bug reports → fix code OR update specs/design → re-verify.
+- [ ] 2.8. Final Verify: regenerate review.md after all fixes to confirm consistency. Skip if 2.7 was not entered.
+- [ ] 2.9. Approval: Only finish on explicit **"Approved"** by the user.
+
+## 3. Standard Tasks (Post-Implementation)
+- [ ] 3.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [ ] 3.2. Bump version
+- [ ] 3.3. Commit and push to remote
+- [ ] 3.4. Update PR: mark ready for review, update body with change summary and issue references if applicable (`gh pr ready && gh pr edit --body "... Closes #X"`)
+
+## 4. Post-Merge Reminders
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -4,8 +4,6 @@ category: reference
 status: stable
 version: 4
 lastModified: 2026-04-10
-status: draft
-change: 2026-04-10-init-health-check-fixes
 ---
 ## Purpose
 

--- a/openspec/specs/three-layer-architecture/spec.md
+++ b/openspec/specs/three-layer-architecture/spec.md
@@ -2,8 +2,10 @@
 order: 13
 category: reference
 status: stable
-version: 3
+version: 4
 lastModified: 2026-04-10
+status: draft
+change: 2026-04-10-init-health-check-fixes
 ---
 ## Purpose
 
@@ -27,14 +29,14 @@ The system SHALL have a `CONSTITUTION.md` file at `openspec/CONSTITUTION.md` tha
 - **THEN** the file SHALL contain Tech Stack, Architecture Rules, Code Style, Constraints, and Conventions sections
 
 ### Requirement: Schema Layer
-The system SHALL use `openspec/WORKFLOW.md` (YAML frontmatter) combined with Smart Templates in `openspec/templates/` to define the 6-stage artifact pipeline. WORKFLOW.md SHALL declare the pipeline order, apply gate, and project context. Post-artifact commit/push logic is handled by the skill during propose pipeline traversal. Each Smart Template SHALL declare its artifact's instruction, output path, and dependencies via YAML frontmatter. Together, WORKFLOW.md and Smart Templates SHALL be the single source of truth for pipeline structure and artifact generation instructions. Skills SHALL read WORKFLOW.md and Smart Templates directly to obtain artifact definitions, instructions, and dependency information.
+The system SHALL use `openspec/WORKFLOW.md` (YAML frontmatter) combined with Smart Templates in `openspec/templates/` to define the 7-stage artifact pipeline. WORKFLOW.md SHALL declare the pipeline order, apply gate, and project context. Post-artifact commit/push logic is handled by the skill during propose pipeline traversal. Each Smart Template SHALL declare its artifact's instruction, output path, and dependencies via YAML frontmatter. Together, WORKFLOW.md and Smart Templates SHALL be the single source of truth for pipeline structure and artifact generation instructions. Skills SHALL read WORKFLOW.md and Smart Templates directly to obtain artifact definitions, instructions, and dependency information.
 
 **User Story:** As a developer I want the artifact pipeline defined declaratively in WORKFLOW.md and self-describing templates, so that I can understand and modify the workflow without editing skill code.
 
 #### Scenario: WORKFLOW.md defines the pipeline order
 - **GIVEN** the `openspec/WORKFLOW.md` file
 - **WHEN** its frontmatter is read by a skill
-- **THEN** it SHALL declare a `pipeline` array with exactly 6 artifact IDs: research, proposal, specs, design, preflight, and tasks in that dependency order
+- **THEN** it SHALL declare a `pipeline` array with exactly 7 artifact IDs: research, proposal, specs, design, preflight, tasks, and review in that dependency order
 
 #### Scenario: Each Smart Template has instruction and metadata
 - **GIVEN** a Smart Template in `openspec/templates/`

--- a/openspec/templates/specs/spec.md
+++ b/openspec/templates/specs/spec.md
@@ -9,7 +9,7 @@ instruction: |
 
   Specs describe behavior, not implementation. Do NOT include concrete
   commands (e.g., git commands), file paths, or API calls in requirement
-  text or scenarios. Implementation details belong in SKILL.md or design.md.
+  text or scenarios.
 
   Overlap Verification (before editing any spec files):
   1. Read the proposal's Consolidation Check section.

--- a/src/.claude-plugin/plugin.json
+++ b/src/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx",
   "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "fritze.dev"
   },

--- a/src/templates/specs/spec.md
+++ b/src/templates/specs/spec.md
@@ -1,11 +1,15 @@
 ---
 id: specs
-template-version: 1
+template-version: 2
 description: Requirements with Gherkin scenarios (BDD) and optional user stories
 generates: "specs/**/*.md"
 requires: [proposal]
 instruction: |
   Edit spec files that define WHAT the system should do.
+
+  Specs describe behavior, not implementation. Do NOT include concrete
+  commands (e.g., git commands), file paths, or API calls in requirement
+  text or scenarios. Implementation details belong in SKILL.md or design.md.
 
   Overlap Verification (before editing any spec files):
   1. Read the proposal's Consolidation Check section.

--- a/src/templates/specs/spec.md
+++ b/src/templates/specs/spec.md
@@ -9,7 +9,7 @@ instruction: |
 
   Specs describe behavior, not implementation. Do NOT include concrete
   commands (e.g., git commands), file paths, or API calls in requirement
-  text or scenarios. Implementation details belong in SKILL.md or design.md.
+  text or scenarios.
 
   Overlap Verification (before editing any spec files):
   1. Read the proposal's Consolidation Check section.

--- a/src/templates/tasks.md
+++ b/src/templates/tasks.md
@@ -1,6 +1,6 @@
 ---
 id: tasks
-template-version: 1
+template-version: 2
 description: Implementation checklist with QA loop
 generates: tasks.md
 requires: [preflight]
@@ -28,8 +28,16 @@ instruction: |
   Standard Tasks: The template includes a section 4 with universal
   post-implementation steps (changelog, docs, version bump, push).
   Always include this section as-is. If the project constitution defines
-  a "## Standard Tasks" section, append its items after the universal
-  steps. Copy constitution items verbatim.
+  a "## Standard Tasks" section with a "### Pre-Merge" subsection,
+  append those pre-merge items (as `- [ ]` checkboxes) after the
+  universal steps in section 4.
+
+  Post-Merge Reminders: If the constitution's Standard Tasks has a
+  "### Post-Merge" subsection, add a separate section 5 titled
+  "Post-Merge Reminders". Copy post-merge items as plain `- ` bullets
+  (no checkbox, no numbering). These are not tracked tasks — just
+  reminders for manual execution after the PR is merged. If no
+  Post-Merge subsection exists, omit section 5 entirely.
 ---
 # Implementation Tasks: [Feature Name]
 
@@ -52,7 +60,12 @@ instruction: |
 
 ## 4. Standard Tasks (Post-Implementation)
 <!-- Universal post-implementation steps. Always include this section.
-     If the constitution defines ## Standard Tasks, append those items after these. -->
+     If the constitution defines ## Standard Tasks > ### Pre-Merge, append those items after these. -->
 - [ ] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
 - [ ] 4.2. Bump version
 - [ ] 4.3. Commit and push to remote
+
+## 5. Post-Merge Reminders
+<!-- Not tracked as tasks. Executed manually after the PR is merged.
+     If the constitution defines ## Standard Tasks > ### Post-Merge, copy those items here as plain bullets.
+     Omit this section entirely if no post-merge items exist. -->


### PR DESCRIPTION
## Summary

Fix three drift issues found by init health check:

- Fix three-layer-architecture spec: "6-stage" → "7-stage" + add "review" to pipeline list
- Upstream tasks.md and specs/spec.md templates to src/templates/ with template-version bump v1→v2
- Add missing custom action hint comments to openspec/WORKFLOW.md

## Capabilities Modified

- `three-layer-architecture`: Schema Layer requirement and scenario now reference 7-stage pipeline
- `project-init`: Template version bumps trigger consumer updates on next init

## Version

v2.0.2