### PR TITLE
Auto-approve runs full propose→apply→finalize without checkpoints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "opsx",
       "source": "./src",
       "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-      "version": "2.0.4"
+      "version": "2.0.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-10 — Auto-Approve Full Flow (v2.0.5)
+
+### Changed
+- `auto_approve: true` now runs the full propose→apply→finalize flow end-to-end without checkpoints — design review, user testing, and cross-action transitions are all auto-continued on success paths; FAIL/BLOCKED/WARNING paths still pause (closes #105)
+
 ## 2026-04-10 — Remove Automation Config (v2.0.4)
 
 ### Removed

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 | Generic fallback dispatch for custom actions; direct execution; dynamic validation against actions array | Minimizes change surface (propose can't be generalized); avoids sub-agent nesting; graceful degradation without WORKFLOW.md | [ADR-042](decisions/adr-042-custom-action-dispatch-design.md) |
 | Uncomment `auto_approve: true` in both WORKFLOW.md and template; update spec default language | Consistency per constitution's template sync rule; existing scenarios already cover true/false behaviors | [ADR-043](decisions/adr-043-auto-approve-default.md) |
 | Remove automation config without deprecation; skip historical artifacts; clean CONSTITUTION.md convention | No consumers depend on it; historical artifacts document their time; stale convention reference would confuse | [ADR-044](decisions/adr-044-remove-automation-config.md) |
+| Auto-dispatch in router for full propose→apply→finalize flow; auto-approve only on clean PASS; design checkpoint opt-out not opt-in | Instructions can't chain across actions; warnings may need review; design review is highest-value checkpoint | [ADR-045](decisions/adr-045-auto-approve-full-flow.md) |
 
 ### Notable Trade-offs
 
@@ -120,6 +121,7 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 - **Custom action instruction quality (ADR-042)**: No spec requirement links for custom actions -- instruction quality depends entirely on the consumer author. Mitigated by clear documentation and the self-contained instruction pattern.
 - **Change context for all custom actions (ADR-042)**: Change context detection runs for every custom action even if not needed; the instruction must handle that case explicitly.
 - **Consumer behavior change on init (ADR-043)**: Consumers who run `init` get auto-approve without explicit opt-in; users who relied on inline checkpoint pauses must set `auto_approve: false` explicitly.
+- **All-or-nothing auto-approve granularity (ADR-045)**: Users who want auto-approve but also want to pause between propose and apply lose that granularity; mitigated by the fact that `auto_approve: false` preserves all checkpoints.
 
 ## Conventions
 
@@ -156,7 +158,7 @@ Layers are independently modifiable -- WORKFLOW.md and Smart Templates do not em
 | [Constitution Management](capabilities/constitution-management.md) | Constitution lifecycle management and global context enforcement |
 | [Quality Gates](capabilities/quality-gates.md) | Preflight during propose, review.md during apply, and docs drift during init |
 | [Task Implementation](capabilities/task-implementation.md) | Sequential task execution with progress tracking and review.md generation |
-| [Human Approval Gate](capabilities/human-approval-gate.md) | QA loop with review.md artifact, fix-verify cycles, and mandatory approval |
+| [Human Approval Gate](capabilities/human-approval-gate.md) | QA loop with review.md artifact, fix-verify cycles, auto_approve bypass, and mandatory approval |
 
 ### Setup
 

--- a/docs/capabilities/human-approval-gate.md
+++ b/docs/capabilities/human-approval-gate.md
@@ -60,7 +60,7 @@ Issues are resolved by fixing code to match the spec or updating the spec to mat
 
 ### Auto-Approve Skips Human Gate
 
-When `auto_approve: true` is set in WORKFLOW.md and review.md's verdict is PASS, the pipeline proceeds directly to finalize without pausing for human approval. A FAIL verdict always stops regardless of the setting.
+When `auto_approve: true` is set in WORKFLOW.md and review.md's verdict is PASS (no CRITICAL, no WARNING), the pipeline skips the user testing pause and proceeds directly to finalize without pausing for human approval. The design review checkpoint during propose is also skipped. A FAIL or BLOCKED verdict always stops regardless of the setting, and PASS WITH WARNINGS still pauses for acknowledgment.
 
 ## Known Limitations
 

--- a/docs/capabilities/human-approval-gate.md
+++ b/docs/capabilities/human-approval-gate.md
@@ -1,7 +1,7 @@
 ---
 title: "Human Approval Gate"
 capability: "human-approval-gate"
-description: "QA loop with review.md artifact, fix-verify cycles, auto_approve config, and mandatory human approval"
+description: "QA loop with review.md artifact, fix-verify cycles, auto_approve bypass, and mandatory human approval"
 lastUpdated: "2026-04-10"
 ---
 

--- a/docs/capabilities/workflow-contract.md
+++ b/docs/capabilities/workflow-contract.md
@@ -25,7 +25,7 @@ A slim WORKFLOW.md handles pipeline orchestration (stage ordering, apply gate, p
 - **Custom actions** -- consumer projects define additional actions by adding names to the `actions` array and writing corresponding `## Action: <name>` body sections with self-contained instructions; no plugin modification required
 - **Router dispatch pattern** -- single router handles all commands (built-in and custom) with shared intent recognition, change context detection, and WORKFLOW.md loading; validates actions against the `actions` array with fallback to built-in list
 - **Template versioning** -- `template-version` (integer, monotonically increasing) enables version-aware merge during `/opsx:workflow init`
-- **Auto-approve default** -- `auto_approve` defaults to `true` when absent or uncommented; pipeline traversal proceeds without user confirmation at checkpoints on success paths; set to `false` to pause at every checkpoint
+- **Auto-approve default** -- `auto_approve` defaults to `true` when absent or uncommented; the full pipeline runs end-to-end without pausing: propose skips the design checkpoint, auto-dispatches apply; apply skips the user testing pause on PASS, auto-dispatches finalize. Set to `false` to pause at every checkpoint (design review, user testing gate, approval).
 
 ## Behavior
 
@@ -35,7 +35,7 @@ The router reads WORKFLOW.md's YAML frontmatter to determine the template direct
 
 ### Auto-Approve Controls Checkpoint Behavior
 
-The `auto_approve` field in WORKFLOW.md frontmatter defaults to `true`. When absent or `true`, pipeline checkpoints (preflight warnings acknowledgment, post-apply PASS) are skipped on success paths. When explicitly set to `false`, the pipeline pauses at each checkpoint for user confirmation. FAIL verdicts always stop regardless of `auto_approve`. The design review checkpoint after the design artifact is a constitutional requirement and is not controlled by `auto_approve` -- it always pauses.
+The `auto_approve` field in WORKFLOW.md frontmatter defaults to `true`. When `true`, the full pipeline runs end-to-end without pausing on success paths: propose skips the design review checkpoint and auto-dispatches apply; apply skips the user testing pause when review.md verdict is PASS and auto-dispatches finalize. When explicitly set to `false`, the pipeline pauses at each checkpoint: design review (user alignment), user testing gate (manual approval), and post-apply approval. FAIL or BLOCKED verdicts always stop regardless of `auto_approve`.
 
 ### Smart Templates Are Self-Describing
 

--- a/docs/decisions/adr-045-auto-approve-full-flow.md
+++ b/docs/decisions/adr-045-auto-approve-full-flow.md
@@ -1,0 +1,33 @@
+# ADR-045: Auto-Approve Full Flow
+
+## Status
+Accepted (2026-04-10)
+
+## Context
+When `auto_approve: true` was introduced (ADR-043), it only affected individual checkpoint behavior within a single action -- preflight warnings auto-continued and post-apply PASS skipped the user testing pause. However, the pipeline still paused at three additional points: the design review checkpoint during propose, the transition from propose to apply, and the transition from apply to finalize. This meant users had to intervene 3-4 times for routine changes where no genuine review was needed. The `auto_approve` flag should mean "run the full pipeline end-to-end, only stopping for real blockers (FAIL, BLOCKED, WARNING)." Achieving this required changes at the router level (cross-action dispatch), in the propose instruction (design checkpoint skip), and in the apply instruction (user testing gate bypass).
+
+## Decision
+Implement auto-dispatch in the router SKILL.md rather than only in action instructions -- instructions control sub-agent behavior within a single action, but chaining across actions (propose to apply to finalize) requires router-level logic that executes after a sub-agent returns. Auto-approve only triggers on a clean PASS verdict with no CRITICAL and no WARNING issues -- warnings may indicate genuine issues worth reviewing, so PASS WITH WARNINGS still pauses for human acknowledgment. Keep the design review checkpoint as the default pause point when `auto_approve` is false -- design review is the highest-value checkpoint where user alignment prevents wasted implementation effort, making it opt-out rather than opt-in.
+
+## Alternatives Considered
+- **Instruction-only approach (no router changes)**: Would work for intra-action checkpoints but cannot chain across actions -- a sub-agent finishing propose has no mechanism to invoke apply.
+- **Auto-approve on PASS WITH WARNINGS too**: Would reduce pauses further but risks finalizing changes with genuine issues the user should review. The conservative approach (PASS only) is safer and can be relaxed later if needed.
+- **Remove design checkpoint entirely**: Would simplify the flow but removes the highest-value feedback point. Users who want no pauses already get that with `auto_approve: true`; users who want pauses benefit most from the design checkpoint.
+
+## Consequences
+
+### Positive
+- `auto_approve: true` now delivers on its promise: a single `/opsx:workflow propose` command runs the entire pipeline through finalize without intervention on success paths
+- Routine changes that pass all quality gates complete in one unattended run
+- FAIL/BLOCKED/WARNING paths still stop, preserving all safety nets
+- No breaking changes -- `auto_approve: false` behavior is unchanged
+
+### Negative
+- Users who want auto-approve but also want to pause between propose and apply lose that granularity (all-or-nothing)
+- Router logic is more complex with conditional dispatch after sub-agent completion
+- If review.md generation has a false-positive PASS, the pipeline will auto-finalize without human review
+
+## References
+- Change: openspec/changes/2026-04-10-auto-approve-full-flow/
+- Specs: openspec/specs/workflow-contract/spec.md, openspec/specs/human-approval-gate/spec.md
+- Issue: #105

--- a/openspec/CONSTITUTION.md
+++ b/openspec/CONSTITUTION.md
@@ -37,7 +37,7 @@ template-version: 1
 - **Local development:** Developers register the local repo as marketplace via `claude plugin marketplace add <local-path> --scope user`. Skill changes reload via `/reload-plugins`. Version changes require `claude plugin update opsx@opsx-enhanced-flow`.
 - **README accuracy:** When plugin behavior changes (skills, WORKFLOW.md, templates, constitution, architecture), update the README to reflect the new state. The README is the primary user-facing documentation and must stay consistent with the implementation.
 - **Workflow friction:** When workflow execution reveals friction, capture it as a GitHub Issue with the `friction` label. Include: what happened, expected behavior, and suggested fix.
-- **Design review checkpoint:** After creating specs + design artifacts, always pause for user alignment before proceeding to preflight/tasks. The design phase is the mandatory review checkpoint in every OpenSpec workflow.
+- **Design review checkpoint:** After creating specs + design artifacts, pause for user alignment before proceeding to preflight/tasks — unless `auto_approve` is true, in which case continue without pausing. When `auto_approve` is false, the design phase is the mandatory review checkpoint.
 - **No ADR references in specs:** Specs MUST NOT reference ADRs (e.g., "see ADR-019"). ADRs are generated after implementation — specs exist before ADRs do. Specs describe requirements; ADRs document the decisions that shaped them.
 - **Template synchronization:** Changes to `openspec/WORKFLOW.md` (actions, pipeline, body sections) must also be reflected in `src/templates/workflow.md`. The `worktree` config may intentionally differ between project and consumer template (e.g., `enabled: true` in project, commented out in consumer).
 

--- a/openspec/WORKFLOW.md
+++ b/openspec/WORKFLOW.md
@@ -35,9 +35,9 @@ Create change workspace if needed, then traverse the pipeline generating artifac
 If no change exists: ask user what to build, derive kebab-case name, create workspace (with worktree if enabled).
 Lazy worktree cleanup: before creating, check for stale worktrees (completed proposals or merged PRs) and clean up.
 Checkpoint/resume: skip completed artifacts, resume from first incomplete step.
-Design review checkpoint: pause after design for user alignment (constitutional requirement).
+Design review checkpoint: when auto_approve is false, pause after design for user alignment. When auto_approve is true, skip the design checkpoint and continue.
 Preflight checkpoint: PASS → continue, PASS WITH WARNINGS → pause for acknowledgment, BLOCKED → stop.
-review artifact: stop before review and suggest /opsx:workflow apply (review is generated during apply, not propose).
+review artifact: when auto_approve is false, stop before review and suggest /opsx:workflow apply. When auto_approve is true, do not stop — auto-continue to apply.
 
 ## Action: init
 
@@ -57,13 +57,13 @@ Report findings, suggest /opsx:workflow propose for changes needed.
 Implement tasks from tasks.md, then generate review.md.
 QA loop: implement → generate review.md → fix if FAIL → regenerate review.md → until PASS.
 Delete existing review.md before starting implementation.
-Pause only at user testing gate.
+When auto_approve is false, pause at user testing gate. When auto_approve is true and review.md verdict is PASS, skip user testing pause and auto-continue to finalize.
 Fix loop: after any fix, regenerate review.md before presenting to user.
 Artifact freshness: update preflight/design if fix resolves flagged issues.
 Standard Tasks (post-implementation section) are NOT part of apply.
 Constitution standard tasks: pre-merge executed during post-apply, post-merge remain as reminders.
 Before committing, mark all standard task checkboxes as complete except post-merge.
-After review.md PASS, commit and push implementation before pausing for user approval.
+After review.md PASS, commit and push implementation. When auto_approve is false, pause for user approval. When auto_approve is true, auto-continue to finalize.
 
 ## Action: finalize
 

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/design.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/design.md
@@ -1,0 +1,84 @@
+<!--
+---
+has_decisions: true
+---
+-->
+# Technical Design: Auto-Approve Full Flow
+
+## Context
+
+`auto_approve: true` currently only controls limited checkpoints (preflight warnings, post-apply PASS). The user expects it to mean "run the entire propose→apply→finalize flow without stopping unless something genuinely fails." Three layers need changes: action instructions (what sub-agents do), specs (behavioral contracts), and the router (cross-action dispatch).
+
+## Architecture & Components
+
+**Layer 1 — Action instructions (WORKFLOW.md):**
+
+| Section | Change |
+|---------|--------|
+| `## Action: propose` | Add: "When auto_approve is true: skip design review checkpoint, and after pipeline completes auto-continue to apply" |
+| `## Action: apply` | Change: "Pause only at user testing gate" → "When auto_approve is true and review.md verdict is PASS: skip user testing pause and auto-continue to finalize" |
+
+**Layer 2 — Specs:**
+
+| Spec | Change |
+|------|--------|
+| `workflow-contract` | Expand auto_approve description; add auto-dispatch scenarios |
+| `human-approval-gate` | Add auto_approve bypass scenarios (already done in specs stage) |
+
+**Layer 3 — Router (SKILL.md):**
+
+| Section | Change |
+|---------|--------|
+| Step 5 `propose` dispatch | Add: after propose completes, if auto_approve is true, auto-dispatch apply |
+| Step 5 `apply` dispatch | Add: after apply sub-agent returns with PASS, if auto_approve is true, auto-dispatch finalize |
+
+**Layer 4 — Constitution + template sync:**
+
+| File | Change |
+|------|--------|
+| `openspec/CONSTITUTION.md` | Update design checkpoint convention to respect auto_approve |
+| `src/templates/workflow.md` | Sync propose + apply instructions |
+
+**Layer 5 — Docs:**
+
+| File | Change |
+|------|--------|
+| `docs/capabilities/workflow-contract.md` | Update auto-approve feature + behavior sections |
+| `docs/capabilities/human-approval-gate.md` | Update to mention auto_approve bypass |
+| `README.md` | No change needed — CLI examples already show the flow |
+
+## Goals & Success Metrics
+
+* WORKFLOW.md propose instruction includes auto_approve condition for design checkpoint skip
+* WORKFLOW.md apply instruction includes auto_approve condition for user testing skip
+* SKILL.md router has auto-dispatch logic: propose→apply when auto_approve true, apply→finalize when auto_approve true and PASS
+* CONSTITUTION.md design checkpoint convention respects auto_approve
+* Consumer template (`src/templates/workflow.md`) synced with WORKFLOW.md instructions
+* FAIL/BLOCKED paths still stop regardless of auto_approve
+
+## Non-Goals
+
+- Adding new WORKFLOW.md fields
+- Changing behavior when `auto_approve: false`
+- Removing the QA loop — it still runs, just auto-approves on PASS
+
+## Decisions
+
+| Decision | Rationale | Alternatives |
+|----------|-----------|--------------|
+| Auto-dispatch in router SKILL.md, not just instructions | Instructions control sub-agent behavior within an action; cross-action chaining requires router-level logic | Instruction-only (can't chain across actions) |
+| Auto-approve only on clean PASS (no CRITICAL, no WARNING) | Warnings may indicate genuine issues worth reviewing | Auto-approve on PASS WITH WARNINGS too |
+| Keep design checkpoint as default pause when auto_approve is false | Design review is the highest-value checkpoint; opt-out, not opt-in | Remove design checkpoint entirely |
+
+## Risks & Trade-offs
+
+- **[Missed review opportunity]** → When auto_approve is true, the user won't see intermediate artifacts. Mitigated by: review.md still generated and visible in PR, user can set `auto_approve: false` for critical changes.
+- **[Router modification]** → Constitution says SKILL.md is immutable for project-specific behavior. This is generic plugin behavior, not project-specific. Acceptable.
+
+## Open Questions
+
+No open questions.
+
+## Assumptions
+
+No assumptions made.

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/preflight.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/preflight.md
@@ -1,0 +1,40 @@
+# Pre-Flight Check: Auto-Approve Full Flow
+
+## A. Traceability Matrix
+
+- [x] Auto-dispatch propose→apply→finalize → Scenario: "Router auto-dispatches" → SKILL.md Step 5
+- [x] Design checkpoint skip → propose instruction → WORKFLOW.md + CONSTITUTION.md
+- [x] User testing skip on PASS → apply instruction → WORKFLOW.md + human-approval-gate spec
+- [x] FAIL/BLOCKED safety → All instructions include guard conditions
+- [x] Template sync → `src/templates/workflow.md`
+- [x] Docs update → `docs/capabilities/workflow-contract.md`, `docs/capabilities/human-approval-gate.md`
+
+## B. Gap Analysis
+
+No gaps. All pause points identified in issue #105 are addressed. FAIL/BLOCKED safety explicitly maintained in all instructions.
+
+## C. Side-Effect Analysis
+
+- **`auto_approve: false` users unaffected**: All changes are gated by `auto_approve: true` conditions
+- **Existing propose/apply/finalize behavior**: Preserved when auto_approve is false
+- **Sub-agent boundaries**: Router handles cross-action dispatch; sub-agents don't need to know about chaining
+
+## D. Constitution Check
+
+Yes — CONSTITUTION.md line 40 needs updating. The design checkpoint convention currently says "always pause." It should say "pause unless auto_approve is true."
+
+## E. Duplication & Consistency
+
+No overlapping stories. workflow-contract and human-approval-gate changes are complementary (one handles router dispatch, the other handles QA loop behavior).
+
+## F. Assumption Audit
+
+No `<!-- ASSUMPTION -->` markers in design.
+
+## G. Review Marker Audit
+
+No `<!-- REVIEW -->` markers found.
+
+---
+
+**Verdict: PASS**

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/proposal.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/proposal.md
@@ -1,0 +1,67 @@
+<!--
+---
+status: active
+branch: worktree-auto-approve-full-flow
+capabilities:
+  new: []
+  modified: [workflow-contract, human-approval-gate]
+  removed: []
+---
+-->
+## Why
+
+When `auto_approve: true`, the workflow still pauses at the design checkpoint, between propose→apply, at the user testing gate, and between apply→finalize. This forces the user to intervene 3-4 times for routine changes where no genuine review is needed. `auto_approve` should mean "run end-to-end, only stop for real blockers." Closes #105.
+
+## What Changes
+
+- Update WORKFLOW.md propose instruction: skip design checkpoint when auto_approve is true
+- Update WORKFLOW.md apply instruction: skip user testing pause when auto_approve is true and review.md verdict is PASS
+- Update SKILL.md router: auto-dispatch propose→apply→finalize when auto_approve is true
+- Update `workflow-contract` spec: expand auto_approve semantics to cover full flow + cross-action dispatch
+- Update `human-approval-gate` spec: add auto_approve bypass scenario for QA loop
+- Update CONSTITUTION.md: make design checkpoint respect auto_approve
+- Sync consumer template (`src/templates/workflow.md`)
+- Update capability docs
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `workflow-contract`: Expand auto_approve semantics — when true, router auto-dispatches propose→apply→finalize; design checkpoint skipped; full end-to-end flow
+- `human-approval-gate`: Add auto_approve bypass — when true and review.md verdict is PASS, QA loop auto-approves without user intervention
+
+### Removed Capabilities
+
+(none)
+
+### Consolidation Check
+
+N/A — no new specs proposed. Two existing specs modified.
+
+Existing specs reviewed: workflow-contract (auto_approve field definition), human-approval-gate (QA loop approval requirement), artifact-pipeline (post-artifact commit), task-implementation (task execution). Only workflow-contract and human-approval-gate need changes.
+
+## Impact
+
+- **WORKFLOW.md**: Propose + apply instructions updated with auto_approve conditions
+- **SKILL.md**: Router gains auto-dispatch logic for propose→apply→finalize
+- **Specs**: workflow-contract (auto_approve semantics), human-approval-gate (bypass scenario)
+- **Constitution**: Design checkpoint convention updated
+- **Consumer template**: Synced instructions
+- **Docs**: Capability docs updated
+
+No breaking change — `auto_approve: false` behavior unchanged. `auto_approve: true` (the default) gains more comprehensive auto-continue behavior.
+
+## Scope & Boundaries
+
+**In scope:**
+- All pause points listed in issue #105
+- Spec, instruction, router, constitution, and doc updates
+
+**Out of scope:**
+- FAIL/BLOCKED paths — these always stop regardless of auto_approve
+- Clarification questions — these always pause
+- New configuration fields — reusing existing `auto_approve`

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/proposal.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/proposal.md
@@ -1,6 +1,6 @@
 <!--
 ---
-status: active
+status: completed
 branch: worktree-auto-approve-full-flow
 capabilities:
   new: []

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/research.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/research.md
@@ -1,0 +1,72 @@
+# Research: Auto-Approve Full Flow
+
+## 1. Current State
+
+`auto_approve: true` in WORKFLOW.md currently controls only limited checkpoint behavior:
+- Preflight warnings acknowledgment (auto-continue on PASS)
+- Post-apply PASS (auto-continue)
+
+It does NOT control:
+- Design review checkpoint (hardcoded as "always pauses" in constitution + propose instruction)
+- Propose → Apply transition (propose always stops and suggests `/opsx:workflow apply`)
+- User Testing Gate in QA loop (always requires explicit "Approved")
+- Apply → Finalize transition (no auto-dispatch exists)
+
+**Files that enforce pauses:**
+
+| File | Pause point | Current behavior |
+|------|------------|------------------|
+| `openspec/WORKFLOW.md` propose instruction | Design checkpoint | "pause after design for user alignment (constitutional requirement)" |
+| `openspec/WORKFLOW.md` propose instruction | Review artifact | "stop before review and suggest /opsx:workflow apply" |
+| `openspec/WORKFLOW.md` apply instruction | User testing | "Pause only at user testing gate" |
+| `openspec/WORKFLOW.md` apply instruction | Post-PASS | "commit and push implementation before pausing for user approval" |
+| `openspec/CONSTITUTION.md` line 40 | Design checkpoint | "always pause for user alignment" |
+| `openspec/specs/human-approval-gate/spec.md` | QA loop | "SHALL require explicit human approval" / "SHALL NOT proceed without" |
+| `openspec/specs/workflow-contract/spec.md` | auto_approve | Only describes checkpoint behavior, not cross-action dispatch |
+| `src/skills/workflow/SKILL.md` | Router dispatch | No auto-dispatch logic between propose→apply→finalize |
+| `docs/capabilities/workflow-contract.md` | Feature docs | Documents current limited auto_approve behavior |
+
+## 2. External Research
+
+No external dependencies. This is an internal behavior change to the workflow orchestration.
+
+## 3. Approaches
+
+| Approach | Pro | Contra |
+|----------|-----|--------|
+| A: Instruction + spec changes only | Minimal change surface; router skill stays generic | Sub-agent boundaries still require manual continuation |
+| B: Instruction + spec + router SKILL.md changes | Full end-to-end flow; router auto-dispatches apply→finalize | Modifies plugin source (SKILL.md) |
+| C: Instruction changes only, rely on agent behavior | No spec changes needed | Soft enforcement, inconsistent behavior |
+
+**Recommendation: Approach B** — the router needs to know about auto_approve to auto-dispatch propose→apply→finalize. The instruction changes tell sub-agents to skip pauses; the router change tells the orchestrator to chain actions.
+
+## 4. Risks & Constraints
+
+- **Router immutability**: Constitution says SKILL.md "MUST NOT be modified for project-specific behavior." But this is a generic plugin feature (auto_approve), not project-specific. The change belongs in the router.
+- **FAIL safety**: Auto-approve must NOT skip pauses when review.md verdict is FAIL or preflight is BLOCKED. Only success paths are auto-continued.
+- **Breaking change**: Users with `auto_approve: false` (or absent, which now defaults to true) are unaffected — the change only adds behavior when true.
+
+## 5. Coverage Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Scope | Clear | Issue #105 lists exact pain points |
+| Behavior | Clear | Skip pauses on success paths when auto_approve is true |
+| Data Model | Clear | No new fields — extends existing auto_approve semantics |
+| UX | Clear | Fewer interruptions for the user |
+| Integration | Clear | Router + instructions + specs |
+| Edge Cases | Clear | FAIL/BLOCKED always stops regardless |
+| Constraints | Clear | Router change is generic, not project-specific |
+| Terminology | Clear | "auto_approve" already established |
+| Non-Functional | Clear | Faster workflow execution |
+
+## 6. Open Questions
+
+All categories are Clear — no questions needed.
+
+## 7. Decisions
+
+| # | Decision | Rationale | Alternatives Considered |
+|---|----------|-----------|------------------------|
+| 1 | Approach B: instruction + spec + router | Full end-to-end flow requires router awareness | Instruction-only (incomplete) |
+| 2 | FAIL/BLOCKED always stops | Safety net for genuine issues | Allow override |

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/review.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/review.md
@@ -1,0 +1,54 @@
+## Review: Auto-Approve Full Flow
+
+### Summary
+| Dimension | Status |
+|-----------|--------|
+| Tasks | 8/8 complete |
+| Requirements | 6/6 verified |
+| Scenarios | 4/4 covered |
+| Scope | Clean / 0 untraced files |
+
+### Requirements Verification
+
+| # | Requirement | Status |
+|---|-------------|--------|
+| 1 | WORKFLOW.md propose instruction includes auto_approve design checkpoint skip | PASS |
+| 2 | WORKFLOW.md apply instruction includes auto_approve user testing skip | PASS |
+| 3 | SKILL.md router has auto-dispatch logic: propose->apply, apply->finalize | PASS |
+| 4 | CONSTITUTION.md design checkpoint convention respects auto_approve | PASS |
+| 5 | Consumer template synced with WORKFLOW.md instructions | PASS |
+| 6 | FAIL/BLOCKED paths still stop regardless of auto_approve | PASS |
+
+### Scenario Coverage
+
+| # | Scenario | Spec | Status |
+|---|----------|------|--------|
+| 1 | Auto-approve bypasses user testing when PASS and auto_approve true | human-approval-gate v3 | Covered: apply instruction skips pause on PASS, SKILL.md auto-dispatches finalize |
+| 2 | Auto-approve does NOT bypass when warnings present | human-approval-gate v3 | Covered: "PASS WITH WARNINGS still pauses for acknowledgment" in docs |
+| 3 | Auto-dispatch propose->apply on success | workflow-contract v5 | Covered: SKILL.md Step 5 propose adds auto-dispatch step |
+| 4 | Auto-dispatch apply->finalize on clean PASS | workflow-contract v5 | Covered: SKILL.md Step 5 apply adds auto-dispatch step |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `openspec/WORKFLOW.md` | Propose: conditional design checkpoint. Apply: conditional user testing pause, conditional post-PASS approval. |
+| `src/skills/workflow/SKILL.md` | Step 5: auto-dispatch propose->apply (step 5), auto-dispatch apply->finalize (step 3) |
+| `openspec/CONSTITUTION.md` | Design checkpoint convention now respects auto_approve |
+| `src/templates/workflow.md` | Synced with WORKFLOW.md propose + apply instruction changes |
+| `docs/capabilities/workflow-contract.md` | Updated auto-approve feature bullet and behavior section |
+| `docs/capabilities/human-approval-gate.md` | Updated Auto-Approve Skips Human Gate section |
+| `openspec/changes/.../tasks.md` | All standard task checkboxes marked complete |
+
+### Findings
+#### CRITICAL
+(none)
+
+#### WARNING
+(none)
+
+#### SUGGESTION
+(none)
+
+### Verdict
+PASS

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/tasks.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/tasks.md
@@ -1,0 +1,40 @@
+# Implementation Tasks: Auto-Approve Full Flow
+
+## 1. Foundation
+
+- [ ] 1.1. Update `openspec/WORKFLOW.md` propose instruction: add auto_approve condition to skip design checkpoint and auto-continue to apply
+- [ ] 1.2. Update `openspec/WORKFLOW.md` apply instruction: add auto_approve condition to skip user testing pause when review.md PASS
+
+## 2. Implementation
+
+- [ ] 2.1. [P] Update `src/skills/workflow/SKILL.md` Step 5 propose dispatch: after propose completes, if auto_approve is true, auto-dispatch apply
+- [ ] 2.2. [P] Update `src/skills/workflow/SKILL.md` Step 5 apply dispatch: after apply sub-agent returns with PASS, if auto_approve is true, auto-dispatch finalize
+- [ ] 2.3. [P] Update `openspec/CONSTITUTION.md` design checkpoint convention to respect auto_approve
+- [ ] 2.4. Sync `src/templates/workflow.md` with updated WORKFLOW.md instructions
+- [ ] 2.5. Update `docs/capabilities/workflow-contract.md` auto-approve feature + behavior sections
+- [ ] 2.6. Update `docs/capabilities/human-approval-gate.md` to mention auto_approve bypass
+
+## 3. QA Loop & Human Approval
+
+- [ ] 3.1. Metric Check: WORKFLOW.md propose instruction contains auto_approve design checkpoint skip
+- [ ] 3.2. Metric Check: WORKFLOW.md apply instruction contains auto_approve user testing skip
+- [ ] 3.3. Metric Check: SKILL.md has auto-dispatch logic for propose→apply and apply→finalize
+- [ ] 3.4. Metric Check: CONSTITUTION.md design checkpoint convention respects auto_approve
+- [ ] 3.5. Metric Check: Consumer template synced with WORKFLOW.md
+- [ ] 3.6. Metric Check: FAIL/BLOCKED paths still stop (verify instruction text)
+- [ ] 3.7. Auto-Verify: generate review.md
+- [ ] 3.8. User Testing: **Stop here!** Ask the user for manual approval.
+- [ ] 3.9. Fix Loop: On verify issues → fix → re-verify.
+- [ ] 3.10. Final Verify: regenerate review.md after fixes. Skip if 3.9 not entered.
+- [ ] 3.11. Approval: Only finish on explicit **"Approved"** by the user.
+
+## 4. Standard Tasks (Post-Implementation)
+
+- [ ] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [ ] 4.2. Bump version
+- [ ] 4.3. Commit and push to remote
+- [ ] 4.4. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #105"`)
+
+## 5. Post-Merge Reminders
+
+- Update plugin locally (`claude plugin marketplace update opsx-enhanced-flow && claude plugin update opsx@opsx-enhanced-flow`)

--- a/openspec/changes/2026-04-10-auto-approve-full-flow/tasks.md
+++ b/openspec/changes/2026-04-10-auto-approve-full-flow/tasks.md
@@ -2,38 +2,38 @@
 
 ## 1. Foundation
 
-- [ ] 1.1. Update `openspec/WORKFLOW.md` propose instruction: add auto_approve condition to skip design checkpoint and auto-continue to apply
-- [ ] 1.2. Update `openspec/WORKFLOW.md` apply instruction: add auto_approve condition to skip user testing pause when review.md PASS
+- [x] 1.1. Update `openspec/WORKFLOW.md` propose instruction: add auto_approve condition to skip design checkpoint and auto-continue to apply
+- [x] 1.2. Update `openspec/WORKFLOW.md` apply instruction: add auto_approve condition to skip user testing pause when review.md PASS
 
 ## 2. Implementation
 
-- [ ] 2.1. [P] Update `src/skills/workflow/SKILL.md` Step 5 propose dispatch: after propose completes, if auto_approve is true, auto-dispatch apply
-- [ ] 2.2. [P] Update `src/skills/workflow/SKILL.md` Step 5 apply dispatch: after apply sub-agent returns with PASS, if auto_approve is true, auto-dispatch finalize
-- [ ] 2.3. [P] Update `openspec/CONSTITUTION.md` design checkpoint convention to respect auto_approve
-- [ ] 2.4. Sync `src/templates/workflow.md` with updated WORKFLOW.md instructions
-- [ ] 2.5. Update `docs/capabilities/workflow-contract.md` auto-approve feature + behavior sections
-- [ ] 2.6. Update `docs/capabilities/human-approval-gate.md` to mention auto_approve bypass
+- [x] 2.1. [P] Update `src/skills/workflow/SKILL.md` Step 5 propose dispatch: after propose completes, if auto_approve is true, auto-dispatch apply
+- [x] 2.2. [P] Update `src/skills/workflow/SKILL.md` Step 5 apply dispatch: after apply sub-agent returns with PASS, if auto_approve is true, auto-dispatch finalize
+- [x] 2.3. [P] Update `openspec/CONSTITUTION.md` design checkpoint convention to respect auto_approve
+- [x] 2.4. Sync `src/templates/workflow.md` with updated WORKFLOW.md instructions
+- [x] 2.5. Update `docs/capabilities/workflow-contract.md` auto-approve feature + behavior sections
+- [x] 2.6. Update `docs/capabilities/human-approval-gate.md` to mention auto_approve bypass
 
 ## 3. QA Loop & Human Approval
 
-- [ ] 3.1. Metric Check: WORKFLOW.md propose instruction contains auto_approve design checkpoint skip
-- [ ] 3.2. Metric Check: WORKFLOW.md apply instruction contains auto_approve user testing skip
-- [ ] 3.3. Metric Check: SKILL.md has auto-dispatch logic for propose→apply and apply→finalize
-- [ ] 3.4. Metric Check: CONSTITUTION.md design checkpoint convention respects auto_approve
-- [ ] 3.5. Metric Check: Consumer template synced with WORKFLOW.md
-- [ ] 3.6. Metric Check: FAIL/BLOCKED paths still stop (verify instruction text)
-- [ ] 3.7. Auto-Verify: generate review.md
-- [ ] 3.8. User Testing: **Stop here!** Ask the user for manual approval.
-- [ ] 3.9. Fix Loop: On verify issues → fix → re-verify.
-- [ ] 3.10. Final Verify: regenerate review.md after fixes. Skip if 3.9 not entered.
-- [ ] 3.11. Approval: Only finish on explicit **"Approved"** by the user.
+- [x] 3.1. Metric Check: WORKFLOW.md propose instruction contains auto_approve design checkpoint skip
+- [x] 3.2. Metric Check: WORKFLOW.md apply instruction contains auto_approve user testing skip
+- [x] 3.3. Metric Check: SKILL.md has auto-dispatch logic for propose→apply and apply→finalize
+- [x] 3.4. Metric Check: CONSTITUTION.md design checkpoint convention respects auto_approve
+- [x] 3.5. Metric Check: Consumer template synced with WORKFLOW.md
+- [x] 3.6. Metric Check: FAIL/BLOCKED paths still stop (verify instruction text)
+- [x] 3.7. Auto-Verify: generate review.md
+- [x] 3.8. User Testing: **Stop here!** Ask the user for manual approval.
+- [x] 3.9. Fix Loop: On verify issues → fix → re-verify.
+- [x] 3.10. Final Verify: regenerate review.md after fixes. Skip if 3.9 not entered.
+- [x] 3.11. Approval: Only finish on explicit **"Approved"** by the user.
 
 ## 4. Standard Tasks (Post-Implementation)
 
-- [ ] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
-- [ ] 4.2. Bump version
-- [ ] 4.3. Commit and push to remote
-- [ ] 4.4. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #105"`)
+- [x] 4.1. Run `/opsx:workflow finalize` (generates changelog and updates docs)
+- [x] 4.2. Bump version
+- [x] 4.3. Commit and push to remote
+- [x] 4.4. Update PR: mark ready for review, update body with change summary and issue references (`gh pr ready && gh pr edit --body "... Closes #105"`)
 
 ## 5. Post-Merge Reminders
 

--- a/openspec/specs/human-approval-gate/spec.md
+++ b/openspec/specs/human-approval-gate/spec.md
@@ -2,7 +2,7 @@
 order: 10
 category: development
 status: stable
-version: 2
+version: 3
 lastModified: 2026-04-10
 ---
 ## Purpose
@@ -13,7 +13,7 @@ Defines the QA loop with mandatory explicit human approval before finalizing, in
 
 ### Requirement: QA Loop with Mandatory Approval
 
-The system SHALL require explicit human approval before a change can proceed to the post-apply workflow. The QA loop consists of: (1) generating `review.md` in the change directory using the review template to produce a persisted verification report, (2) presenting findings to the user, and (3) waiting for an explicit "Approved" response. The system SHALL NOT proceed without receiving explicit human approval. Approval SHALL only be requested after verification has been run and all CRITICAL issues have been resolved. The tasks.md template SHALL include a QA Loop section with an explicit human approval checkbox that MUST be checked before proceeding. Every Success Metric from design.md SHALL be carried over as a PASS/FAIL checkbox in the QA Loop section.
+The system SHALL require explicit human approval before a change can proceed to the post-apply workflow, unless `auto_approve: true` is set in WORKFLOW.md and the review.md verdict is PASS (no CRITICAL or WARNING issues). When auto_approve is true and review passes cleanly, the system SHALL auto-approve and proceed without pausing. The QA loop consists of: (1) generating `review.md` in the change directory using the review template to produce a persisted verification report, (2) presenting findings to the user, and (3) waiting for an explicit "Approved" response. The system SHALL NOT proceed without receiving explicit human approval. Approval SHALL only be requested after verification has been run and all CRITICAL issues have been resolved. The tasks.md template SHALL include a QA Loop section with an explicit human approval checkbox that MUST be checked before proceeding. Every Success Metric from design.md SHALL be carried over as a PASS/FAIL checkbox in the QA Loop section.
 
 Approval SHALL be gated by a final verification pass. After the Fix Loop completes (all CRITICAL issues resolved, code and specs in sync), a final `review.md` SHALL be regenerated (Final Verify step) before the user is asked for approval. This ensures that all changes made during the Fix Loop — including spec updates, design changes, and code fixes — are verified as consistent before finalizing. If the Fix Loop was not entered (first verify was clean), the Final Verify step can be marked complete immediately.
 
@@ -63,6 +63,23 @@ The QA Loop SHALL include the following steps in order: Metric Check, Auto-Verif
 - **THEN** the system SHALL regenerate `review.md` one final time (Final Verify)
 - **AND** the final verify report SHALL confirm 0 CRITICAL issues
 - **AND** only then SHALL the system proceed to request Approval
+
+#### Scenario: Auto-approve bypasses user testing when PASS and auto_approve true
+
+- **GIVEN** `auto_approve: true` in WORKFLOW.md
+- **AND** apply generates `review.md` with verdict PASS and 0 CRITICAL / 0 WARNING issues
+- **WHEN** the QA loop reaches the User Testing step
+- **THEN** the system SHALL skip the user testing pause
+- **AND** SHALL auto-mark the Approval checkbox as complete
+- **AND** SHALL proceed to the post-apply workflow
+
+#### Scenario: Auto-approve does NOT bypass when warnings present
+
+- **GIVEN** `auto_approve: true` in WORKFLOW.md
+- **AND** apply generates `review.md` with verdict PASS WITH WARNINGS
+- **WHEN** the QA loop reaches the User Testing step
+- **THEN** the system SHALL pause for user review of the warnings
+- **AND** SHALL NOT auto-approve
 
 #### Scenario: Final verify skipped when first verify is clean
 

--- a/openspec/specs/workflow-contract/spec.md
+++ b/openspec/specs/workflow-contract/spec.md
@@ -2,7 +2,7 @@
 order: 3
 category: reference
 status: stable
-version: 4
+version: 5
 lastModified: 2026-04-10
 ---
 ## Purpose
@@ -21,7 +21,7 @@ The system SHALL support an `openspec/WORKFLOW.md` file as the pipeline orchestr
 - `pipeline` (ordered array of artifact step IDs — each generates a file)
 - `actions` (array of action names, e.g., `[init, propose, apply, finalize]` — each has a corresponding `## Action: <name>` body section)
 - `worktree` (optional object with `enabled`, `path_pattern`, `auto_cleanup`)
-- `auto_approve` (optional boolean, defaults to `true` — pipeline traversal proceeds without user confirmation at checkpoints; set to `false` to pause at every checkpoint)
+- `auto_approve` (optional boolean, defaults to `true` — when true, the full propose→apply→finalize flow runs end-to-end without checkpoints on success paths; when false, pauses at every checkpoint including design review, preflight, user testing, and cross-action transitions)
 - `docs_language` (optional, defaults to English)
 
 **Markdown body** — prose instructions as named sections:
@@ -157,6 +157,21 @@ The system SHALL provide a single router skill that handles all user-facing comm
 - **AND** SHALL read the `### Instruction` from the `## Action: qa-review` section
 - **AND** SHALL execute the instruction directly (agent decides execution mode)
 - **AND** SHALL NOT look for requirement links in SKILL.md
+
+#### Scenario: Router auto-dispatches propose→apply→finalize when auto_approve is true
+- **GIVEN** `auto_approve: true` in WORKFLOW.md
+- **AND** the user invokes `/opsx:workflow propose my-feature`
+- **WHEN** propose completes successfully (all pipeline artifacts generated)
+- **THEN** the router SHALL automatically dispatch apply without pausing
+- **AND** when apply completes with review.md verdict PASS, SHALL automatically dispatch finalize
+- **AND** SHALL only pause if a FAIL verdict, BLOCKED preflight, or genuine clarification question occurs
+
+#### Scenario: Router pauses at each transition when auto_approve is false
+- **GIVEN** `auto_approve: false` in WORKFLOW.md
+- **AND** the user invokes `/opsx:workflow propose my-feature`
+- **WHEN** propose completes
+- **THEN** the router SHALL stop and suggest `/opsx:workflow apply`
+- **AND** SHALL NOT auto-dispatch subsequent actions
 
 #### Scenario: Router rejects action not in actions array
 - **GIVEN** a WORKFLOW.md with `actions: [init, propose, apply, finalize]`

--- a/src/.claude-plugin/plugin.json
+++ b/src/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx",
   "description": "Spec-driven development workflow — every feature produces research, specs, architecture, quality checks, changelogs, and user docs alongside code.",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": {
     "name": "fritze.dev"
   },

--- a/src/skills/workflow/SKILL.md
+++ b/src/skills/workflow/SKILL.md
@@ -105,6 +105,7 @@ For `propose`, `apply`, `finalize`:
    - On first push (no PR exists): `gh pr create --draft --title "<Change Name>" --body "WIP: <change-name>"`
    - Skip PR creation if `gh` unavailable. Continue on push failure.
 4. Follow the instruction from `## Action: propose` for checkpoint behavior, workspace creation, and pipeline gates
+5. **Auto-dispatch to apply**: If `auto_approve` is `true` in WORKFLOW.md frontmatter and propose completed successfully (all pipeline artifacts generated, no BLOCKED preflight), automatically dispatch the `apply` action using the same change context. Do NOT pause or suggest `/opsx:workflow apply` — proceed directly.
 
 ### `apply` — Sub-Agent Execution
 
@@ -114,6 +115,7 @@ For `propose`, `apply`, `finalize`:
    - The extracted requirement sections as behavioral context
    - Change directory path and artifact paths
    - The sub-agent implements tasks, generates review.md, runs the QA loop
+3. **Auto-dispatch to finalize**: If `auto_approve` is `true` and the apply sub-agent completed with review.md verdict PASS (no CRITICAL, no WARNING), automatically dispatch the `finalize` action using the same change context. Do NOT pause for user approval — proceed directly.
 
 ### `finalize` — Sub-Agent Execution
 

--- a/src/templates/workflow.md
+++ b/src/templates/workflow.md
@@ -35,9 +35,9 @@ Create change workspace if needed, then traverse the pipeline generating artifac
 If no change exists: ask user what to build, derive kebab-case name, create workspace (with worktree if enabled).
 Lazy worktree cleanup: before creating, check for stale worktrees (completed proposals or merged PRs) and clean up.
 Checkpoint/resume: skip completed artifacts, resume from first incomplete step.
-Design review checkpoint: pause after design for user alignment (constitutional requirement).
+Design review checkpoint: when auto_approve is false, pause after design for user alignment. When auto_approve is true, skip the design checkpoint and continue.
 Preflight checkpoint: PASS → continue, PASS WITH WARNINGS → pause for acknowledgment, BLOCKED → stop.
-review artifact: stop before review and suggest /opsx:workflow apply (review is generated during apply, not propose).
+review artifact: when auto_approve is false, stop before review and suggest /opsx:workflow apply. When auto_approve is true, do not stop — auto-continue to apply.
 
 ## Action: init
 
@@ -57,13 +57,13 @@ Report findings, suggest /opsx:workflow propose for changes needed.
 Implement tasks from tasks.md, then generate review.md.
 QA loop: implement → generate review.md → fix if FAIL → regenerate review.md → until PASS.
 Delete existing review.md before starting implementation.
-Pause only at user testing gate.
+When auto_approve is false, pause at user testing gate. When auto_approve is true and review.md verdict is PASS, skip user testing pause and auto-continue to finalize.
 Fix loop: after any fix, regenerate review.md before presenting to user.
 Artifact freshness: update preflight/design if fix resolves flagged issues.
 Standard Tasks (post-implementation section) are NOT part of apply.
 Constitution standard tasks: pre-merge executed during post-apply, post-merge remain as reminders.
 Before committing, mark all standard task checkboxes as complete except post-merge.
-After review.md PASS, commit and push implementation before pausing for user approval.
+After review.md PASS, commit and push implementation. When auto_approve is false, pause for user approval. When auto_approve is true, auto-continue to finalize.
 
 ## Action: finalize
 


### PR DESCRIPTION
## Summary

- `auto_approve: true` now runs the full propose→apply→finalize flow end-to-end without checkpoints — design review, user testing, and cross-action transitions are all auto-continued on success paths
- FAIL/BLOCKED/WARNING paths still pause regardless of `auto_approve` setting
- Updated `workflow-contract` spec (v5) and `human-approval-gate` spec (v3)

## Changes

- **WORKFLOW.md**: Propose instruction skips design checkpoint; apply instruction skips user testing pause on PASS
- **SKILL.md**: Router auto-dispatches propose→apply→finalize when `auto_approve: true`
- **CONSTITUTION.md**: Design checkpoint convention respects `auto_approve`
- **Specs**: `workflow-contract` (auto_approve semantics, router dispatch scenario), `human-approval-gate` (auto-approve bypass scenarios)
- **Consumer template** (`src/templates/workflow.md`): Synced instructions
- **Capability docs**: `workflow-contract.md`, `human-approval-gate.md` updated
- **ADR-045**: Documents design decisions (router-level dispatch, PASS-only auto-approve, design checkpoint as default)
- **Version**: 2.0.4 → 2.0.5

Closes #105